### PR TITLE
Add required fields as prefills to input schemas

### DIFF
--- a/templates/project_cheerio_crawler/INPUT_SCHEMA.json
+++ b/templates/project_cheerio_crawler/INPUT_SCHEMA.json
@@ -8,7 +8,10 @@
       "title": "Start URLs",
       "type": "array",
       "description": "URLs to start with.",
-      "editor": "requestListSources"
+      "editor": "requestListSources",
+      "prefill": [
+        { "url": "https://apify.com" }
+      ]
     }
   },
   "required": [

--- a/templates/project_playwright_crawler/INPUT_SCHEMA.json
+++ b/templates/project_playwright_crawler/INPUT_SCHEMA.json
@@ -8,7 +8,10 @@
       "title": "Start URLs",
       "type": "array",
       "description": "URLs to start with.",
-      "editor": "requestListSources"
+      "editor": "requestListSources",
+      "prefill": [
+        { "url": "https://apify.com" }
+      ]
     }
   },
   "required": [

--- a/templates/project_puppeteer_crawler/INPUT_SCHEMA.json
+++ b/templates/project_puppeteer_crawler/INPUT_SCHEMA.json
@@ -8,7 +8,10 @@
       "title": "Start URLs",
       "type": "array",
       "description": "URLs to start with.",
-      "editor": "requestListSources"
+      "editor": "requestListSources",
+      "prefill": [
+        { "url": "https://apify.com" }
+      ]
     }
   },
   "required": [


### PR DESCRIPTION
This PR adds prefill values to INPUT_SCHEMAS of cheerio, pupetteer and playwright crawlers, so that the actor created from this template could be started with no changes. The run itself can fail later.

Letting know @metalwarrior665 