### PR TITLE
Add getting started templates

### DIFF
--- a/templates/getting_started_node/.actor/actor.json
+++ b/templates/getting_started_node/.actor/actor.json
@@ -1,0 +1,43 @@
+{
+    "actorSpecification": 1,
+    "name": "getting-started-actor",
+    "title": "Getting Started Actor",
+    "description": "Adds two integers.",
+    "version": "0.0.1",
+    "storages": {
+        "dataset": {
+            "title": "Numbers and their sums",
+            "views": {
+                "sums": {
+                    "transformation": {
+                        "fields": [
+                            "firstNumber",
+                            "secondNumber",
+                            "sum"
+                        ]
+                    },
+                    "display": {
+                        "component": "table",
+                        "columns": [
+                            {
+                                "label": "First number",
+                                "format": "number",
+                                "field": "firstNumber"
+                            },
+                            {
+                                "label": "Second number",
+                                "format": "number",
+                                "field": "secondNumber"
+                            },
+                            {
+                                "label": "Sum",
+                                "format": "number",
+                                "field": "sum"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/templates/getting_started_node/Dockerfile
+++ b/templates/getting_started_node/Dockerfile
@@ -1,0 +1,33 @@
+# First, specify the base Docker image. You can read more about
+# the available images at https://sdk.apify.com/docs/guides/docker-images
+# You can also use any other image from Docker Hub.
+FROM apify/actor-node:16
+
+# Second, copy just package.json and package-lock.json since it should be
+# the only file that affects "npm install" in the next step, to speed up the build
+COPY package*.json ./
+
+# Install NPM packages, skip optional and development dependencies to
+# keep the image small. Avoid logging too much and print the dependency
+# tree for debugging
+RUN npm --quiet set progress=false \
+ && npm install --only=prod --no-optional \
+ && echo "Installed NPM packages:" \
+ && (npm list --only=prod --no-optional --all || true) \
+ && echo "Node.js version:" \
+ && node --version \
+ && echo "NPM version:" \
+ && npm --version
+
+# Next, copy the remaining files and directories with the source code.
+# Since we do this after NPM install, quick build will be really fast
+# for most source file changes.
+COPY . ./
+
+# Optionally, specify how to launch the source code of your actor.
+# By default, Apify's base Docker images define the CMD instruction
+# that runs the Node.js source code using the command specified
+# in the "scripts.start" section of the package.json file.
+# In short, the instruction looks something like this:
+#
+# CMD npm start

--- a/templates/getting_started_node/INPUT_SCHEMA.json
+++ b/templates/getting_started_node/INPUT_SCHEMA.json
@@ -1,0 +1,20 @@
+{
+  "title": "Add two integers",
+  "type": "object",
+  "schemaVersion": 1,
+  "properties": {
+    "firstNumber": {
+      "title": "First integer",
+      "type": "integer",
+      "description": "The number you want to add to the second number.",
+      "editor": "number"
+    },
+    "secondNumber": {
+      "title": "Second integer",
+      "type": "integer",
+      "description": "The number you want to add to the first number.",
+      "editor": "number"
+    }
+  },
+  "required": ["firstNumber", "secondNumber"]
+}

--- a/templates/getting_started_node/README.md
+++ b/templates/getting_started_node/README.md
@@ -1,0 +1,19 @@
+# Getting started with Apify actors
+
+The `README.md` file documents what your actor does and how to use it,
+which is then displayed in the Console or Apify Store. It's always a good
+idea to write a `README.md`. In a few months, not even you
+will remember all the details about the actor.
+
+You can use [Markdown](https://www.markdownguide.org/cheat-sheet)
+language for rich formatting.
+
+## Documentation reference
+
+- [Apify SDK](https://sdk.apify.com/)
+- [Apify Actor documentation](https://docs.apify.com/actor)
+- [Apify CLI](https://docs.apify.com/cli)
+
+## Writing a README
+
+See our tutorial on [writing READMEs for your actors](https://help.apify.com/en/articles/2912548-how-to-write-great-readme-for-your-actors) if you need more inspiration.

--- a/templates/getting_started_node/package.json
+++ b/templates/getting_started_node/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "getting-started-node",
+    "version": "0.0.1",
+    "description": "This is an example of an Apify actor.",
+    "dependencies": {
+        "apify": "^2.3.0"
+    },
+    "devDependencies": {},
+    "scripts": {
+        "start": "node src/main.js",
+        "test": "echo \"Error: oops, the actor has no tests yet, sad!\" && exit 1"
+    },
+    "author": "It's not you it's me",
+    "license": "ISC"
+}

--- a/templates/getting_started_node/src/main.js
+++ b/templates/getting_started_node/src/main.js
@@ -14,7 +14,7 @@ Apify.main(async () => {
     // 👉 Complete the code so that result is
     // the sum of firstNumber and secondNumber.
     // 👇👇👇👇👇👇👇👇👇👇
-    const result = ;
+    const result = null;
     // 👆👆👆👆👆👆👆👆👆👆
 
     console.log('The result is: ', result);

--- a/templates/getting_started_node/src/main.js
+++ b/templates/getting_started_node/src/main.js
@@ -1,0 +1,28 @@
+// This is the main Node.js source code file of your actor.
+// An actor is a program that takes an input and produces an output.
+
+// For more information, see https://sdk.apify.com/
+const Apify = require('apify');
+
+Apify.main(async () => {
+    console.log('Loading input')
+    // Structure of input is defined in INPUT_SCHEMA.json.
+    const input = await Apify.getInput();
+    console.log('First number: ', input.firstNumber);
+    console.log('Second number: ', input.secondNumber);
+
+    // 👉 Complete the code so that result is
+    // the sum of firstNumber and secondNumber.
+    // 👇👇👇👇👇👇👇👇👇👇
+    const result = ;
+    // 👆👆👆👆👆👆👆👆👆👆
+
+    console.log('The result is: ', result);
+
+    // Structure of output is defined in .actor/actor.json
+    await Apify.pushData({
+        firstNumber: input.firstNumber,
+        secondNumber: input.secondNumber,
+        sum: result,
+    })
+});

--- a/templates/getting_started_python/.actor/actor.json
+++ b/templates/getting_started_python/.actor/actor.json
@@ -1,0 +1,43 @@
+{
+    "actorSpecification": 1,
+    "name": "getting-started-actor",
+    "title": "Getting Started Actor",
+    "description": "Adds two integers.",
+    "version": "0.0.1",
+    "storages": {
+        "dataset": {
+            "title": "Numbers and their sums",
+            "views": {
+                "sums": {
+                    "transformation": {
+                        "fields": [
+                            "first_number",
+                            "second_number",
+                            "sum"
+                        ]
+                    },
+                    "display": {
+                        "component": "table",
+                        "columns": [
+                            {
+                                "label": "First number",
+                                "format": "number",
+                                "field": "first_number"
+                            },
+                            {
+                                "label": "Second number",
+                                "format": "number",
+                                "field": "second_number"
+                            },
+                            {
+                                "label": "Sum",
+                                "format": "number",
+                                "field": "sum"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/templates/getting_started_python/Dockerfile
+++ b/templates/getting_started_python/Dockerfile
@@ -1,0 +1,30 @@
+# First, specify the base Docker image.
+# You can see the Docker images from Apify at https://hub.docker.com/r/apify/.
+# You can also use any other image from Docker Hub.
+FROM apify/actor-python:3.9
+
+# Second, copy just requirements.txt into the actor image,
+# since it should be the only file that affects "pip install" in the next step,
+# in order to speed up the build
+COPY requirements.txt ./
+
+# Install the packages specified in requirements.txt,
+# Print the installed Python version, pip version
+# and all installed packages with their versions for debugging
+RUN echo "Python version:" \
+ && python --version \
+ && echo "Pip version:" \
+ && pip --version \
+ && echo "Installing dependencies from requirements.txt:" \
+ && pip install -r requirements.txt \
+ && echo "All installed Python packages:" \
+ && pip freeze
+
+# Next, copy the remaining files and directories with the source code.
+# Since we do this after installing the dependencies, quick build will be really fast
+# for most source file changes.
+COPY . ./
+
+# Specify how to launch the source code of your actor.
+# By default, the main.py file is run
+CMD python3 main.py

--- a/templates/getting_started_python/INPUT_SCHEMA.json
+++ b/templates/getting_started_python/INPUT_SCHEMA.json
@@ -1,0 +1,20 @@
+{
+  "title": "Add two integers",
+  "type": "object",
+  "schemaVersion": 1,
+  "properties": {
+    "first_number": {
+      "title": "First integer",
+      "type": "integer",
+      "description": "The number you want to add to the second number.",
+      "editor": "number"
+    },
+    "second_number": {
+      "title": "Second integer",
+      "type": "integer",
+      "description": "The number you want to add to the first number.",
+      "editor": "number"
+    }
+  },
+  "required": ["first_number", "second_number"]
+}

--- a/templates/getting_started_python/README.md
+++ b/templates/getting_started_python/README.md
@@ -1,0 +1,19 @@
+# Getting started with Apify actors
+
+The `README.md` file documents what your actor does and how to use it,
+which is then displayed in the Console or Apify Store. It's always a good
+idea to write a `README.md`. In a few months, not even you
+will remember all the details about the actor.
+
+You can use [Markdown](https://www.markdownguide.org/cheat-sheet)
+language for rich formatting.
+
+## Documentation reference
+
+- [Apify SDK](https://sdk.apify.com/)
+- [Apify Actor documentation](https://docs.apify.com/actor)
+- [Apify CLI](https://docs.apify.com/cli)
+
+## Writing a README
+
+See our tutorial on [writing READMEs for your actors](https://help.apify.com/en/articles/2912548-how-to-write-great-readme-for-your-actors) if you need more inspiration.

--- a/templates/getting_started_python/main.py
+++ b/templates/getting_started_python/main.py
@@ -1,0 +1,41 @@
+import json
+import os
+
+from apify_client import ApifyClient
+
+
+# Run the main function of the script, if the script is executed directly
+if __name__ == '__main__':
+    # Initialize the main ApifyClient instance
+    client = ApifyClient(os.environ['APIFY_TOKEN'], api_url=os.environ['APIFY_API_BASE_URL'])
+
+    # Get the resource subclient for working with the default key-value store of the actor
+    default_kv_store_client = client.key_value_store(os.environ['APIFY_DEFAULT_KEY_VALUE_STORE_ID'])
+
+    # Get the value of the actor input and print it
+    print('Loading input')
+    actor_input = default_kv_store_client.get_record(os.environ['APIFY_INPUT_KEY'])['value']
+
+    # Structure of input is defined in INPUT_SCHEMA.json
+    print(f'First number: {actor_input.first_number}')
+    print(f'Second number: {actor_input.second_number}')
+
+    # 👉 Complete the code so that result is
+    # the sum of first_number and second_number.
+    # 👇👇👇👇👇👇👇👇👇👇
+    result =
+    # 👆👆👆👆👆👆👆👆👆👆
+
+    print(f'The result is: {result}')
+
+    # Get the resource subclient for working with the default dataset of the actor
+    default_dataset_client = client.dataset(os.environ['APIFY_DEFAULT_DATASET_ID'])
+
+    # Structure of output is defined in .actor/actor.json
+    default_dataset_client.push_items([
+        {
+            'first_number': first_number,
+            'second_number': second_number,
+            'sum': result
+        },
+    ])

--- a/templates/getting_started_python/main.py
+++ b/templates/getting_started_python/main.py
@@ -1,5 +1,4 @@
 import os
-
 from apify_client import ApifyClient
 
 
@@ -22,7 +21,7 @@ if __name__ == '__main__':
     # 👉 Complete the code so that result is
     # the sum of first_number and second_number.
     # 👇👇👇👇👇👇👇👇👇👇
-    result =
+    result = null
     # 👆👆👆👆👆👆👆👆👆👆
 
     print(f'The result is: {result}')

--- a/templates/getting_started_python/main.py
+++ b/templates/getting_started_python/main.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 from apify_client import ApifyClient

--- a/templates/getting_started_python/requirements.txt
+++ b/templates/getting_started_python/requirements.txt
@@ -1,0 +1,3 @@
+# Add your dependencies here.
+# See https://pip.pypa.io/en/latest/cli/pip_install/#requirements-file-format
+# for how to format them

--- a/templates/getting_started_typescript/.actor/actor.json
+++ b/templates/getting_started_typescript/.actor/actor.json
@@ -1,0 +1,43 @@
+{
+    "actorSpecification": 1,
+    "name": "getting-started-actor",
+    "title": "Getting Started Actor",
+    "description": "Adds two integers.",
+    "version": "0.0.1",
+    "storages": {
+        "dataset": {
+            "title": "Numbers and their sums",
+            "views": {
+                "sums": {
+                    "transformation": {
+                        "fields": [
+                            "firstNumber",
+                            "secondNumber",
+                            "sum"
+                        ]
+                    },
+                    "display": {
+                        "component": "table",
+                        "columns": [
+                            {
+                                "label": "First number",
+                                "format": "number",
+                                "field": "firstNumber"
+                            },
+                            {
+                                "label": "Second number",
+                                "format": "number",
+                                "field": "secondNumber"
+                            },
+                            {
+                                "label": "Sum",
+                                "format": "number",
+                                "field": "sum"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/templates/getting_started_typescript/Dockerfile
+++ b/templates/getting_started_typescript/Dockerfile
@@ -1,0 +1,33 @@
+# First, specify the base Docker image. You can read more about
+# the available images at https://sdk.apify.com/docs/guides/docker-images
+# You can also use any other image from Docker Hub.
+FROM apify/actor-node:16
+
+# Second, copy just package.json and package-lock.json since it should be
+# the only file that affects "npm install" in the next step, to speed up the build
+COPY package*.json ./
+
+# Install NPM packages, skip optional and development dependencies to
+# keep the image small. Avoid logging too much and print the dependency
+# tree for debugging
+RUN npm --quiet set progress=false \
+ && npm install --only=prod --no-optional \
+ && echo "Installed NPM packages:" \
+ && (npm list --only=prod --no-optional --all || true) \
+ && echo "Node.js version:" \
+ && node --version \
+ && echo "NPM version:" \
+ && npm --version
+
+# Next, copy the remaining files and directories with the source code.
+# Since we do this after NPM install, quick build will be really fast
+# for most source file changes.
+COPY . ./
+
+# Optionally, specify how to launch the source code of your actor.
+# By default, Apify's base Docker images define the CMD instruction
+# that runs the Node.js source code using the command specified
+# in the "scripts.start" section of the package.json file.
+# In short, the instruction looks something like this:
+#
+# CMD npm start

--- a/templates/getting_started_typescript/Dockerfile
+++ b/templates/getting_started_typescript/Dockerfile
@@ -1,33 +1,28 @@
-# First, specify the base Docker image. You can read more about
-# the available images at https://sdk.apify.com/docs/guides/docker-images
-# You can also use any other image from Docker Hub.
-FROM apify/actor-node:16
+# using multistage build, as we need dev deps to build the TS source code
+FROM node:16 AS builder
 
-# Second, copy just package.json and package-lock.json since it should be
-# the only file that affects "npm install" in the next step, to speed up the build
-COPY package*.json ./
-
-# Install NPM packages, skip optional and development dependencies to
-# keep the image small. Avoid logging too much and print the dependency
-# tree for debugging
-RUN npm --quiet set progress=false \
- && npm install --only=prod --no-optional \
- && echo "Installed NPM packages:" \
- && (npm list --only=prod --no-optional --all || true) \
- && echo "Node.js version:" \
- && node --version \
- && echo "NPM version:" \
- && npm --version
-
-# Next, copy the remaining files and directories with the source code.
-# Since we do this after NPM install, quick build will be really fast
-# for most source file changes.
+# copy all files, install all dependencies (including dev deps) and build the project
 COPY . ./
+RUN npm install \
+    && npm run build
 
-# Optionally, specify how to launch the source code of your actor.
-# By default, Apify's base Docker images define the CMD instruction
-# that runs the Node.js source code using the command specified
-# in the "scripts.start" section of the package.json file.
-# In short, the instruction looks something like this:
-#
-# CMD npm start
+# create final image, copy only package.json, readme and compiled code
+FROM apify/actor-node:16
+COPY --from=builder /package*.json ./
+COPY --from=builder /README.md ./
+COPY --from=builder /dist ./dist
+COPY --from=builder /.actor ./.actor
+COPY --from=builder /INPUT_SCHEMA.json ./INPUT_SCHEMA.json
+
+# install only prod deps
+RUN npm --quiet set progress=false \
+    && npm install --only=prod --no-optional \
+    && echo "Installed NPM packages:" \
+    && (npm list --only=prod --no-optional --all || true) \
+    && echo "Node.js version:" \
+    && node --version \
+    && echo "NPM version:" \
+    && npm --version
+
+# run compiled code
+CMD npm run start:prod

--- a/templates/getting_started_typescript/INPUT_SCHEMA.json
+++ b/templates/getting_started_typescript/INPUT_SCHEMA.json
@@ -1,0 +1,20 @@
+{
+  "title": "Add two integers",
+  "type": "object",
+  "schemaVersion": 1,
+  "properties": {
+    "firstNumber": {
+      "title": "First integer",
+      "type": "integer",
+      "description": "The number you want to add to the second number.",
+      "editor": "number"
+    },
+    "secondNumber": {
+      "title": "Second integer",
+      "type": "integer",
+      "description": "The number you want to add to the first number.",
+      "editor": "number"
+    }
+  },
+  "required": ["firstNumber", "secondNumber"]
+}

--- a/templates/getting_started_typescript/README.md
+++ b/templates/getting_started_typescript/README.md
@@ -1,0 +1,19 @@
+# Getting started with Apify actors
+
+The `README.md` file documents what your actor does and how to use it,
+which is then displayed in the Console or Apify Store. It's always a good
+idea to write a `README.md`. In a few months, not even you
+will remember all the details about the actor.
+
+You can use [Markdown](https://www.markdownguide.org/cheat-sheet)
+language for rich formatting.
+
+## Documentation reference
+
+- [Apify SDK](https://sdk.apify.com/)
+- [Apify Actor documentation](https://docs.apify.com/actor)
+- [Apify CLI](https://docs.apify.com/cli)
+
+## Writing a README
+
+See our tutorial on [writing READMEs for your actors](https://help.apify.com/en/articles/2912548-how-to-write-great-readme-for-your-actors) if you need more inspiration.

--- a/templates/getting_started_typescript/package.json
+++ b/templates/getting_started_typescript/package.json
@@ -8,7 +8,7 @@
     "devDependencies": {
         "@apify/tsconfig": "^0.1.0",
         "ts-node": "^10.3.0",
-        "typescript": "^4.4.4"
+        "typescript": "^4.6.3"
     },
     "scripts": {
         "start": "npm run start:dev",

--- a/templates/getting_started_typescript/package.json
+++ b/templates/getting_started_typescript/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "getting-started-typescript",
+    "version": "0.0.1",
+    "description": "This is an example of an Apify actor.",
+    "dependencies": {
+        "apify": "^2.3.0"
+    },
+    "devDependencies": {
+        "@apify/tsconfig": "^0.1.0",
+        "ts-node": "^10.3.0",
+        "typescript": "^4.4.4"
+    },
+    "scripts": {
+        "start": "npm run start:dev",
+        "start:prod": "node dist/main.js",
+        "start:dev": "ts-node -T src/main.ts",
+        "build": "tsc",
+        "test": "echo \"Error: oops, the actor has no tests yet, sad!\" && exit 1"
+    },
+    "author": "It's not you it's me",
+    "license": "ISC"
+}

--- a/templates/getting_started_typescript/src/main.ts
+++ b/templates/getting_started_typescript/src/main.ts
@@ -19,7 +19,7 @@ Apify.main(async () => {
     // 👉 Complete the code so that result is
     // the sum of firstNumber and secondNumber.
     // 👇👇👇👇👇👇👇👇👇👇
-    const result = ;
+    const result = null;
     // 👆👆👆👆👆👆👆👆👆👆
 
     console.log('The result is: ', result);

--- a/templates/getting_started_typescript/src/main.ts
+++ b/templates/getting_started_typescript/src/main.ts
@@ -1,0 +1,33 @@
+// This is the main Node.js source code file of your actor.
+// An actor is a program that takes an input and produces an output.
+
+// For more information, see https://sdk.apify.com/
+import Apify from 'apify';
+
+interface InputSchema {
+    firstNumber: number;
+    secondNumber: number;
+}
+
+Apify.main(async () => {
+    console.log('Loading input')
+    // Structure of input is defined in INPUT_SCHEMA.json.
+    const input = await Apify.getInput() as InputSchema;
+    console.log('First number: ', input.firstNumber);
+    console.log('Second number: ', input.secondNumber);
+
+    // 👉 Complete the code so that result is
+    // the sum of firstNumber and secondNumber.
+    // 👇👇👇👇👇👇👇👇👇👇
+    const result = ;
+    // 👆👆👆👆👆👆👆👆👆👆
+
+    console.log('The result is: ', result);
+
+    // Structure of output is defined in .actor/actor.json
+    await Apify.pushData({
+        firstNumber: input.firstNumber,
+        secondNumber: input.secondNumber,
+        sum: result,
+    })
+});

--- a/templates/getting_started_typescript/tsconfig.json
+++ b/templates/getting_started_typescript/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "@apify/tsconfig",
+    "compilerOptions": {
+        "skipLibCheck": true,
+        "outDir": "dist"
+    },
+    "include": [
+        "./src/**/*"
+    ]
+}

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -3,7 +3,7 @@
     {
       "name": "project_empty",
       "description": "Project: Empty - Standard and up to date project template with very little boilerplate code.",
-      "archiveUrl": "https://github.com/apifytech/actor-templates/blob/master/dist/templates/project_empty.zip?raw=true",
+      "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/project_empty.zip?raw=true",
       "defaultRunOptions": {
         "build": "latest",
         "memoryMbytes": 2048,
@@ -13,7 +13,7 @@
     {
       "name": "project_cheerio_crawler",
       "description": "Project: CheerioCrawler - Standard and up to date template for developing with Cheerio.",
-      "archiveUrl": "https://github.com/apifytech/actor-templates/blob/master/dist/templates/project_cheerio_crawler.zip?raw=true",
+      "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/project_cheerio_crawler.zip?raw=true",
       "defaultRunOptions": {
         "build": "latest",
         "memoryMbytes": 512,
@@ -24,7 +24,7 @@
     {
       "name": "project_puppeteer_crawler",
       "description": "Project: PuppeteerCrawler - Standard and up to date template for developing with Puppeteer.",
-      "archiveUrl": "https://github.com/apifytech/actor-templates/blob/master/dist/templates/project_puppeteer_crawler.zip?raw=true",
+      "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/project_puppeteer_crawler.zip?raw=true",
       "defaultRunOptions": {
         "build": "latest",
         "memoryMbytes": 4096,
@@ -34,7 +34,7 @@
     {
       "name": "project_playwright_crawler",
       "description": "Project: PlaywrightCrawler - Standard and up to date template for developing with Playwright.",
-      "archiveUrl": "https://github.com/apifytech/actor-templates/blob/master/dist/templates/project_playwright_crawler.zip?raw=true",
+      "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/project_playwright_crawler.zip?raw=true",
       "defaultRunOptions": {
         "build": "latest",
         "memoryMbytes": 4096,
@@ -44,7 +44,7 @@
     {
       "name": "example_hello_world",
       "description": "Example: Hello world - The smallest actor you will see today, it only takes input and generates output.",
-      "archiveUrl": "https://github.com/apifytech/actor-templates/blob/master/dist/templates/example_hello_world.zip?raw=true",
+      "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/example_hello_world.zip?raw=true",
       "defaultRunOptions": {
         "build": "latest",
         "memoryMbytes": 256,
@@ -55,7 +55,7 @@
     {
       "name": "example_puppeteer_single_page",
       "description": "Example: Puppeteer single page - Load a single web page using Chrome and Puppeteer and extract data from it.",
-      "archiveUrl": "https://github.com/apifytech/actor-templates/blob/master/dist/templates/example_puppeteer_single_page.zip?raw=true",
+      "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/example_puppeteer_single_page.zip?raw=true",
       "defaultRunOptions": {
         "build": "latest",
         "memoryMbytes": 2048,
@@ -65,7 +65,7 @@
     {
       "name": "example_python",
       "description": "Example: Hello world in Python - A simple Python actor from which you can start developing",
-      "archiveUrl": "https://github.com/apifytech/actor-templates/blob/master/dist/templates/example_python.zip?raw=true",
+      "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/example_python.zip?raw=true",
       "defaultRunOptions": {
         "build": "latest",
         "memoryMbytes": 256,
@@ -75,11 +75,21 @@
     {
       "name": "example_typescript",
       "description": "Example: Hello world in TypeScript - A simple TypeScript actor from which you can start developing",
-      "archiveUrl": "https://github.com/apifytech/actor-templates/blob/master/dist/templates/example_typescript.zip?raw=true",
+      "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/example_typescript.zip?raw=true",
       "defaultRunOptions": {
         "build": "latest",
         "memoryMbytes": 256,
         "timeoutSecs": 3600
+      }
+    },
+    {
+      "name": "getting_started_node",
+      "description": "A showcase of basic actor functionality on the Apify platform.",
+      "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/getting_started_node.zip?raw=true",
+      "defaultRunOptions": {
+        "build": "latest",
+        "memoryMbytes": 256,
+        "timeoutSecs": 360
       }
     }
   ]

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -91,6 +91,26 @@
         "memoryMbytes": 256,
         "timeoutSecs": 360
       }
+    },
+    {
+      "name": "getting_started_typescript",
+      "description": "A showcase of basic actor functionality on the Apify platform.",
+      "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/getting_started_typescript.zip?raw=true",
+      "defaultRunOptions": {
+        "build": "latest",
+        "memoryMbytes": 256,
+        "timeoutSecs": 360
+      }
+    },
+    {
+      "name": "getting_started_python",
+      "description": "A showcase of basic actor functionality on the Apify platform.",
+      "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/getting_started_python.zip?raw=true",
+      "defaultRunOptions": {
+        "build": "latest",
+        "memoryMbytes": 256,
+        "timeoutSecs": 360
+      }
     }
   ]
 }

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -11,12 +11,11 @@ const { TEMPLATE_NAMES } = require('../src/consts');
 const TEST_ACTORS_FOLDER = 'test-actors';
 const APIFY_LATEST_VERSION = spawnSync('npm', ['view', 'apify', 'version']).stdout.toString().trim();
 
-const checkTemplateStructureAndRun = async (actorName) => {
+const checkTemplateStructure = async (actorName) => {
     process.chdir(actorName);
     spawnSync('npm', ['install']);
     process.chdir('../');
 
-    const apifyJsonPath = path.join(actorName, 'apify.json');
     // Check files structure
     expect(fs.existsSync(actorName)).toBe(true);
     // Python templates do not have package.json, but have requirements.txt
@@ -25,7 +24,6 @@ const checkTemplateStructureAndRun = async (actorName) => {
     } else {
         expect(fs.existsSync(path.join(actorName, 'requirements.txt'))).toBe(true);
     }
-    expect(fs.existsSync(apifyJsonPath)).toBe(true);
 
     // python templates do not use apify package
     if (!/python/i.test(actorName)) {
@@ -36,14 +34,15 @@ const checkTemplateStructureAndRun = async (actorName) => {
 
     // Check if actor was created without errors
     expect(console.log.args.map((arg) => arg[0])).not.toContain('Error:');
+};
 
+const checkTemplateRun = async (actorName) => {
     process.chdir(actorName);
     spawnSync('apify', ['run']);
     process.chdir('../');
-
     // Check if actor run without errors
     expect(console.log.args.map((arg) => arg[0])).not.toContain('Error:');
-};
+}
 
 let prevEnvHeadless;
 
@@ -75,7 +74,8 @@ describe('templates', () => {
         test(`${templateName} works`, async () => {
             const actorName = `cli-test-${templateName.replace(/_/g, '-')}`;
             await copy(`../templates/${templateName}`, actorName, { dot: true });
-            await checkTemplateStructureAndRun(actorName, templateName);
+            await checkTemplateStructure(actorName);
+            await checkTemplateRun(actorName);
         });
     });
 });

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -42,7 +42,7 @@ const checkTemplateRun = async (actorName) => {
     process.chdir('../');
     // Check if actor run without errors
     expect(console.log.args.map((arg) => arg[0])).not.toContain('Error:');
-}
+};
 
 let prevEnvHeadless;
 


### PR DESCRIPTION
Adding templates that should be used in developer onboarding flow of the Console. It should work approximately like this:

1. Users are prompted to create an actor.
2. They are presented with 3 language choices - Node, TS, Python
3. Depending on choice, the proper getting started template is selected
4. They are prompted to complete the missing piece of code
5. Build
6. Prompted to go to Input - which will have input schema
7. Fill in input
8. Run
9. Output schema should kick in and show nice table
10. Prompt to either deploy code from GitHub (go to GitHub guide), from local (CLI guide) or continue browsing Console.

@B4nan pls check the TS. I skipped build, because the code would not build, as there is a piece missing.
@fnesveda pls check the Python. I used your original example and quite naively updated it to match the other templates.