### PR TITLE
Revert "use npm ci instead of npm install"

### DIFF
--- a/templates/crawlee_cheerio_typescript/Dockerfile
+++ b/templates/crawlee_cheerio_typescript/Dockerfile
@@ -3,7 +3,7 @@ FROM apify/actor-node:16 AS builder
 
 # copy all files, install all dependencies (including dev deps) and build the project
 COPY . ./
-RUN npm ci --include=dev \
+RUN npm install --include=dev \
     && npm run build
 
 # create final image
@@ -17,7 +17,7 @@ COPY --from=builder /usr/src/app/INPUT_SCHEMA.json ./INPUT_SCHEMA.json
 
 # install only prod deps
 RUN npm --quiet set progress=false \
-    && npm ci --only=prod --no-optional \
+    && npm install --only=prod --no-optional \
     && echo "Installed NPM packages:" \
     && (npm list --only=prod --no-optional --all || true) \
     && echo "Node.js version:" \

--- a/templates/crawlee_playwright_typescript/Dockerfile
+++ b/templates/crawlee_playwright_typescript/Dockerfile
@@ -3,7 +3,7 @@ FROM apify/actor-node:16 AS builder
 
 # copy all files, install all dependencies (including dev deps) and build the project
 COPY . ./
-RUN npm ci --include=dev \
+RUN npm install --include=dev \
     && npm run build
 
 # create final image
@@ -17,7 +17,7 @@ COPY --from=builder /usr/src/app/INPUT_SCHEMA.json ./INPUT_SCHEMA.json
 
 # install only prod deps
 RUN npm --quiet set progress=false \
-    && npm ci --only=prod --no-optional \
+    && npm install --only=prod --no-optional \
     && echo "Installed NPM packages:" \
     && (npm list --only=prod --no-optional --all || true) \
     && echo "Node.js version:" \

--- a/templates/crawlee_puppeteer_typescript/Dockerfile
+++ b/templates/crawlee_puppeteer_typescript/Dockerfile
@@ -3,7 +3,7 @@ FROM apify/actor-node:16 AS builder
 
 # copy all files, install all dependencies (including dev deps) and build the project
 COPY . ./
-RUN npm ci --include=dev \
+RUN npm install --include=dev \
     && npm run build
 
 # create final image
@@ -17,7 +17,7 @@ COPY --from=builder /usr/src/app/INPUT_SCHEMA.json ./INPUT_SCHEMA.json
 
 # install only prod deps
 RUN npm --quiet set progress=false \
-    && npm ci --only=prod --no-optional \
+    && npm install --only=prod --no-optional \
     && echo "Installed NPM packages:" \
     && (npm list --only=prod --no-optional --all || true) \
     && echo "Node.js version:" \

--- a/templates/example_hello_world/Dockerfile
+++ b/templates/example_hello_world/Dockerfile
@@ -11,7 +11,7 @@ COPY package*.json ./
 # keep the image small. Avoid logging too much and print the dependency
 # tree for debugging
 RUN npm --quiet set progress=false \
- && npm ci --only=prod --no-optional \
+ && npm install --only=prod --no-optional \
  && echo "Installed NPM packages:" \
  && (npm list --only=prod --no-optional --all || true) \
  && echo "Node.js version:" \

--- a/templates/example_puppeteer_single_page/Dockerfile
+++ b/templates/example_puppeteer_single_page/Dockerfile
@@ -11,7 +11,7 @@ COPY package*.json ./
 # keep the image small. Avoid logging too much and print the dependency
 # tree for debugging
 RUN npm --quiet set progress=false \
- && npm ci --only=prod --no-optional \
+ && npm install --only=prod --no-optional \
  && echo "Installed NPM packages:" \
  && (npm list --only=prod --no-optional --all || true) \
  && echo "Node.js version:" \

--- a/templates/example_typescript/Dockerfile
+++ b/templates/example_typescript/Dockerfile
@@ -3,7 +3,7 @@ FROM apify/actor-node:16 AS builder
 
 # copy all files, install all dependencies (including dev deps) and build the project
 COPY . ./
-RUN npm ci --include=dev \
+RUN npm install --include=dev \
     && npm run build
 
 # create final image, copy only package.json, readme and compiled code
@@ -16,7 +16,7 @@ COPY --from=builder /usr/src/app/INPUT_SCHEMA.json ./INPUT_SCHEMA.json
 
 # install only prod deps
 RUN npm --quiet set progress=false \
-    && npm ci --only=prod --no-optional \
+    && npm install --only=prod --no-optional \
     && echo "Installed NPM packages:" \
     && (npm list --only=prod --no-optional --all || true) \
     && echo "Node.js version:" \

--- a/templates/getting_started_typescript/Dockerfile
+++ b/templates/getting_started_typescript/Dockerfile
@@ -3,7 +3,7 @@ FROM apify/actor-node:16 AS builder
 
 # copy all files, install all dependencies (including dev deps) and build the project
 COPY . ./
-RUN npm ci --include=dev \
+RUN npm install --include=dev \
     && npm run build
 
 # create final image
@@ -17,7 +17,7 @@ COPY --from=builder /usr/src/app/INPUT_SCHEMA.json ./INPUT_SCHEMA.json
 
 # install only prod deps
 RUN npm --quiet set progress=false \
-    && npm ci --only=prod --no-optional \
+    && npm install --only=prod --no-optional \
     && echo "Installed NPM packages:" \
     && (npm list --only=prod --no-optional --all || true) \
     && echo "Node.js version:" \

--- a/templates/project_cheerio_crawler/Dockerfile
+++ b/templates/project_cheerio_crawler/Dockerfile
@@ -11,7 +11,7 @@ COPY package*.json ./
 # keep the image small. Avoid logging too much and print the dependency
 # tree for debugging
 RUN npm --quiet set progress=false \
- && npm ci --only=prod --no-optional \
+ && npm install --only=prod --no-optional \
  && echo "Installed NPM packages:" \
  && (npm list --only=prod --no-optional --all || true) \
  && echo "Node.js version:" \

--- a/templates/project_empty/Dockerfile
+++ b/templates/project_empty/Dockerfile
@@ -11,7 +11,7 @@ COPY package*.json ./
 # keep the image small. Avoid logging too much and print the dependency
 # tree for debugging
 RUN npm --quiet set progress=false \
- && npm ci --only=prod --no-optional \
+ && npm install --only=prod --no-optional \
  && echo "Installed NPM packages:" \
  && (npm list --only=prod --no-optional --all || true) \
  && echo "Node.js version:" \

--- a/templates/project_playwright_crawler/Dockerfile
+++ b/templates/project_playwright_crawler/Dockerfile
@@ -11,7 +11,7 @@ COPY package*.json ./
 # keep the image small. Avoid logging too much and print the dependency
 # tree for debugging
 RUN npm --quiet set progress=false \
- && npm ci --only=prod --no-optional \
+ && npm install --only=prod --no-optional \
  && echo "Installed NPM packages:" \
  && (npm list --only=prod --no-optional --all || true) \
  && echo "Node.js version:" \

--- a/templates/project_puppeteer_crawler/Dockerfile
+++ b/templates/project_puppeteer_crawler/Dockerfile
@@ -11,7 +11,7 @@ COPY package*.json ./
 # keep the image small. Avoid logging too much and print the dependency
 # tree for debugging
 RUN npm --quiet set progress=false \
- && npm ci --only=prod --no-optional \
+ && npm install --only=prod --no-optional \
  && echo "Installed NPM packages:" \
  && (npm list --only=prod --no-optional --all || true) \
  && echo "Node.js version:" \


### PR DESCRIPTION
Reverts apify/actor-templates#98

As it is not possible to run `npm ci` without existing lock file. 