### PR TITLE
Fix output schema in getting started TS

### DIFF
--- a/templates/getting_started_typescript/.actor/actor.json
+++ b/templates/getting_started_typescript/.actor/actor.json
@@ -19,22 +19,19 @@
                         ]
                     },
                     "display": {
-                        "component": "table",
-                        "display": {
-                            "component": "table",
-                            "properties": {
-                                "sum": {
-                                    "label": "Sum",
-                                    "format": "number"
-                                },
-                                "firstNumber": {
-                                    "label": "First number",
-                                    "format": "number"
-                                },
-                                "secondNumber": {
-                                    "label": "Second number",
-                                    "format": "number"
-                                }
+                        "component": "table",                        
+                        "properties": {
+                            "sum": {
+                                "label": "Sum",
+                                "format": "number"
+                            },
+                            "firstNumber": {
+                                "label": "First number",
+                                "format": "number"
+                            },
+                            "secondNumber": {
+                                "label": "Second number",
+                                "format": "number"
                             }
                         }
                     }


### PR DESCRIPTION
I was testing my changes on staging and noticed this:
<img width="707" alt="Snímek obrazovky 2022-11-04 v 11 26 06" src="https://user-images.githubusercontent.com/1233185/199950847-c5978b76-5277-4e30-80ef-88916ee5c99b.png">

Turns out that the default output schema for `Getting started: TypeScript` is wrong - the display object contains another display object...
