### PR TITLE
update templates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,85 +1,95 @@
 <img src="actor-logo.png" align="right" />
 
 # Apify Actor templates
+
 > This repository stores boilerplate templates and code examples for [Apify Actor](https://apify.com/actors).
-  The template helps you to get started with your Apify project quickly.
+> The purpose of these templates is to help devlopers get started with actor development on the Apify platform.
 
 ## How to use the templates
 
-You can start using them right away in Apify command-line interface:
+You can start using the actor templates right away with the [Apify CLI](https://docs.apify.com/cli):
 
+```Bash
+npx apify-cli create my-crawler
 ```
+
+or
+
+```Bash
 npm -g install apify-cli
 apify create my-actor
 ```
 
-It displays an interactive list of templates for you to choose from.
-See [Apify CLI documentation](https://docs.apify.com/cli) for more details.
+After running the command you will be prompted to select one of the templates from the list displayed in your terminal. The available templates are:
+
+### Getting started templates
+
+Basic templates to start developing actors on the Apify platform using Node.js (JavaScript/Typescript), or Python.
+Just install the CLI and watch your actor run.
+
+- [Node.js + JavaScript](./templates/getting_started_node/)
+- [Node.js + TypeScript](./templates/getting_started_typescript/)
+- [Python](./templates/getting_started_python/)
+
+You can find more code examples in the
+[Apify SDK documentation](https://sdk.apify.com/docs/examples/puppeteer-crawler/).
+
+### Project boilerplate
+
+If you're already familiar with actors, you can use the following templates to bootstrap new projects using an empty project template or Crawlee templates:
+
+- [Empty project](./templates/project_empty/) - Template with very little boilerplate code.
+- [CheerioCrawler](./templates/project_cheerio_crawler_js/) ([TypeScript version](./templates/project_cheerio_crawler_ts/)) - Standard and up to date template for developing with Crawlee's CheerioCrawler.
+- [PlaywrightCrawler](./templates/project_playwright_crawler_js/) ([TypeScript version](./templates/project_playwright_crawler_ts/)) - Standard and up to date template for developing with Crawlee's PlaywrightCrawler.
+- [PuppeteerCrawler](./templates/project_cheerio_crawler_js/) ([TypeScript version](./templates/project_puppeteer_crawler_ts/)) - Standard and up to date template for developing with Crawlee's PuppeteerCrawler.
 
 To run the template:
 
-```
+```Bash
 cd my-actor
 apify run
 ```
-
-## Getting started examples
-The examples provide a quick and easy way to get to know Apify actors.
-Just install the CLI and watch your actor run.
-
-- [Node.js](./templates/getting_started_node)
-- [TypeScript](./templates/getting_started_ts)
-- [Python](./templates/getting_started_python)
-
-You can find more code examples in the [examples folder](./examples) and in the
-[Apify SDK documentation](https://sdk.apify.com/docs/examples/puppeteer-crawler/).
-
-## Project boilerplate
-If you're already familiar with actors, you can use the following templates to bootstrap new projects quickly:
-
-- [Empty project](./templates/project_empty) - Template with very little boilerplate code.
-- [Cheerio crawler](./templates/project_cheerio_crawler) - Standard and up to date template for developing with CheerioCrawler.
-- [Puppeteer crawler](./templates/project_puppeteer_crawler) - Standard and up to date template for developing with PuppeteerCrawler.
 
 ## Templates API
 
 The [template manifest](./templates/manifest.json) can be fetched programmatically.
 Apify CLI uses this to always fetch the most up to date templates.
 
-```
+```Bash
 npm i @apify/actor-templates
 ```
 
-```js
-const templates = require('@apify/actor-templates');
+```JavaScript
+const templates = require("@apify/actor-templates");
 
-const manifest = await templates.fetchManifest(); 
+const manifest = await templates.fetchManifest();
 ```
 
 ## Publish updated/new template
 
 All templates are stores in `./templates` directory.
-For each template needs to create an archive of whole source code into `./dist/templates` directory.
-The archive is used to to create a boilerplate template in apify CLI or other places in Apify system.
+For each template needs to create an archive of whole source code into the `./dist/templates` directory.
+The archive is used to to create a boilerplate template in `apify CLI` or other places in the Apify system.
 
 ### Update and add templates
 
-If you want to change template, you need to update the files and [`manifest.json`](./templates/manifest.json)
-and then push to master. After pushing to master, the archive will be automatically built using Github actions.
+If you want to change a template, you will have to update the template files and the [`manifest.json`](./templates/manifest.json) file before pushing the changes to the `master` branch. After pushing to `master`, the archive will be automatically built using Github actions.
 
 ## How to propagate templates into Apify CLI
 
-Templates are propagated to Apify CLI templates, you can choose one of the templates when using the `apify create` command.
-The propagation happens after committing a new version of templates into `master` branch. After tests succeeded the Github action
-builds archives of each template and pushes these archives into the repository. The CLI command then uses those archives
+Templates are propagated to Apify CLI templates. You can then find your newly added template when using the `apify create` command.
+The propagation happens after committing a new version of the template into the `master` branch. After tests succeeded the Github action
+builds `archives` of each template and pushes these `archives` into the repository. The CLI command then uses those archives
 to bootstrap your project folder. We did it this way because we can update template structure/code without publishing
 any package to npm. It makes templates changes agile.
 
 ## Reference
+
 - [Apify Actor documentation](https://docs.apify.com/actor)
 - [Apify CLI](https://docs.apify.com/cli)
 - [Apify SDK](https://sdk.apify.com/)
 
 ## Contributing
+
 If you have any ideas for improvements, either submit an issue or create a pull request.
 For contribution guidelines and the code of conduct, see [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
Update the README to reflect the current actor template structure, as specified in this Notion document -> https://www.notion.so/apify/Make-changes-to-the-template-s-description-in-GitHub-f7841752371c4da6b3d4d4c5bb90bc49

We might have to revisit this README after the Python SDK launch and the addition of new Python templates.