### PR TITLE
fix: move dev dependencies to regular dependencies

### DIFF
--- a/templates/ts-playwright-test-runner/package.json
+++ b/templates/ts-playwright-test-runner/package.json
@@ -15,14 +15,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@apify/eslint-config-ts": "^0.2.3",
+    "@apify/tsconfig": "^0.1.0"
     "@playwright/test": "^1.30.0",
     "@types/uuid": "^9.0.1",
     "apify": "^3.1.2",
     "ts-node": "^10.9.1",
     "uuid": "^9.0.0"
-  },
-  "devDependencies": {
-    "@apify/eslint-config-ts": "^0.2.3",
-    "@apify/tsconfig": "^0.1.0"
   }
 }

--- a/templates/ts-playwright-test-runner/package.json
+++ b/templates/ts-playwright-test-runner/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "@apify/eslint-config-ts": "^0.2.3",
-    "@apify/tsconfig": "^0.1.0"
+    "@apify/tsconfig": "^0.1.0",
     "@playwright/test": "^1.30.0",
     "@types/uuid": "^9.0.1",
     "apify": "^3.1.2",


### PR DESCRIPTION
This template is using the dev mode currently, which uses ts-node and hence requires tsconfig to be present.

Also moved the eslint config dependency there to be safer, we should clean this up later, together with changes in the dockerfile (unless there is an actual need to run things with ts-node).