### PR TITLE
fix: Specify the same Chrome and Chromedriver version in tests

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -124,8 +124,8 @@ jobs:
 
     - name: Setup Chromedriver
       run: |
-        npx @puppeteer/browsers install chrome@stable
-        npx @puppeteer/browsers install chromedriver@stable
+        npx @puppeteer/browsers install chrome@115.0.5790.102
+        npx @puppeteer/browsers install chromedriver@115.0.5790.102
 
     - name: Test Python templates
       run: npm run test-python-templates

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -122,10 +122,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install Chrome
+      run: npx @puppeteer/browsers install chrome@113.0.5672.63
+
     - name: Setup Chromedriver
-      run: |
-        npx @puppeteer/browsers install chrome@115.0.5790.102
-        npx @puppeteer/browsers install chromedriver@115.0.5790.102
+      uses: nanasess/setup-chromedriver@v2
+      with:
+        chromedriver-version: '113.0.5672.63'
 
     - name: Test Python templates
       run: npm run test-python-templates

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -123,7 +123,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Chrome and Chromedriver
-      run:
+      run: |
         npx @puppeteer/browsers install chrome@113.0.5672.63
         npx @puppeteer/browsers install chromedriver@113.0.5672.63
 

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -122,13 +122,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install Chrome
-      run: npx @puppeteer/browsers install chrome@113.0.5672.63
-
-    - name: Setup Chromedriver
-      uses: nanasess/setup-chromedriver@v2
-      with:
-        chromedriver-version: '113.0.5672.63'
+    - name: Install Chrome and Chromedriver
+      run:
+        npx @puppeteer/browsers install chrome@113.0.5672.63
+        npx @puppeteer/browsers install chromedriver@113.0.5672.63
 
     - name: Test Python templates
       run: npm run test-python-templates

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -123,7 +123,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup Chromedriver
-      uses: nanasess/setup-chromedriver@v2
+      run: |
+        npx @puppeteer/browsers install chrome@stable
+        npx @puppeteer/browsers install chromedriver@stable
 
     - name: Test Python templates
       run: npm run test-python-templates

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -124,8 +124,6 @@ jobs:
 
     - name: Setup Chromedriver
       uses: nanasess/setup-chromedriver@v2
-      with:
-        chromedriver-version: '113.0.5672.63'
 
     - name: Test Python templates
       run: npm run test-python-templates


### PR DESCRIPTION
Apparently, if you pass `chromedriver-version` to `setup-chromedriver`, it will install the given Chromedriver version, but it will also install latest Chrome which might not be compatible to the given Chromedriver version. 

There is now a better way to install the same Chrome and Chromedriver, using [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) and `npx @puppeteer/browsers install ...`.