### PR TITLE
Add Twisted version constraint

### DIFF
--- a/templates/python-scrapy/requirements.txt
+++ b/templates/python-scrapy/requirements.txt
@@ -1,6 +1,10 @@
 # Add your dependencies here.
 # See https://pip.pypa.io/en/latest/reference/requirements-file-format/
 # for how to format them
-apify ~= 1.1.1
-nest-asyncio ~= 1.5.6
-scrapy ~= 2.9.0
+apify ~= 1.1.3
+nest-asyncio ~= 1.5.7
+scrapy ~= 2.10.0
+
+# Version >= 23 causes the throwing of the following exception:
+# AttributeError: 'AsyncioSelectorReactor' object has no attribute '_handleSignals'
+Twisted < 23.0.0


### PR DESCRIPTION
Closes #178 

It's Scrapy's bug - https://github.com/scrapy/scrapy/issues/6024 , this PR provides a hotfix.

Remove it once the Scrapy gets updated / Twisted fixes it on their side 