### PR TITLE
chore: Update Apify CLI installation instructions via Homebrew

### DIFF
--- a/templates/console_readme_suffix.md
+++ b/templates/console_readme_suffix.md
@@ -14,7 +14,7 @@ If you would like to develop locally, you can pull the existing Actor from Apify
     **Using Homebrew**
 
     ```
-    brew install apify/tap/apify-cli
+    brew install apify-cli
     ```
 
     **Using NPM**


### PR DESCRIPTION
The Apify CLI was accepted into `homebrew-core`, so the installation instructions got a bit simpler.