### PR TITLE
Fix set logging level in Python Scrapy template

### DIFF
--- a/templates/python-scrapy/requirements.txt
+++ b/templates/python-scrapy/requirements.txt
@@ -1,6 +1,6 @@
 # Add your dependencies here.
 # See https://pip.pypa.io/en/latest/reference/requirements-file-format/
 # for how to format them
-apify ~= 1.1.4
+apify ~= 1.1.5
 nest-asyncio ~= 1.5.7
 scrapy ~= 2.11.0


### PR DESCRIPTION
### Description

- Add an option to configure a logging level
    - for all the loggers out there - `apify`, `apify_client`, `scrapy`, `twisted`, `filelock`, `hpack`
    - and on one place - at the beginning on the `__main__.py` file as a constant `LOGGING_LEVEL`

### Ticket

- Closes #185

### Additional relevant changes

- Since these Scrapy-Actor apps contain 6 different loggers I think it could be valuable to have a logger name at the beginning.
- Check the https://github.com/apify/apify-sdk-python/pull/116.