### PR TITLE
fix ts-node on node 20 + update all images to use node 18

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [ 16, 18 ]
+        node-version: [ 16, 18, 20 ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/templates/js-crawlee-cheerio/.actor/Dockerfile
+++ b/templates/js-crawlee-cheerio/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://docs.apify.com/sdk/js/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:16
+FROM apify/actor-node:18
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/templates/js-crawlee-playwright-chrome/.actor/Dockerfile
+++ b/templates/js-crawlee-playwright-chrome/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-playwright-chrome:16
+FROM apify/actor-node-playwright-chrome:18-1.37.1
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/templates/js-crawlee-playwright-chrome/package.json
+++ b/templates/js-crawlee-playwright-chrome/package.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "apify": "^3.0.0",
         "crawlee": "^3.0.0",
-        "playwright": "*"
+        "playwright": "1.37.1"
     },
     "devDependencies": {
         "@apify/eslint-config": "^0.3.1",

--- a/templates/js-crawlee-puppeteer-chrome/.actor/Dockerfile
+++ b/templates/js-crawlee-puppeteer-chrome/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-puppeteer-chrome:16
+FROM apify/actor-node-puppeteer-chrome:18
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/templates/ts-bootstrap-cheerio-crawler/package.json
+++ b/templates/ts-bootstrap-cheerio-crawler/package.json
@@ -22,7 +22,7 @@
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",
-        "start:dev": "ts-node-esm -T src/main.ts",
+        "start:dev": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only src/main.ts",
         "build": "tsc",
         "lint": "eslint ./src --ext .ts",
         "lint:fix": "eslint ./src --ext .ts --fix",

--- a/templates/ts-crawlee-cheerio/.actor/Dockerfile
+++ b/templates/ts-crawlee-cheerio/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:16 AS builder
+FROM apify/actor-node:18 AS builder
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.
@@ -19,7 +19,7 @@ COPY . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node:16
+FROM apify/actor-node:18
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/templates/ts-crawlee-cheerio/package.json
+++ b/templates/ts-crawlee-cheerio/package.json
@@ -22,7 +22,7 @@
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",
-        "start:dev": "ts-node-esm -T src/main.ts",
+        "start:dev": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only src/main.ts",
         "build": "tsc",
         "lint": "eslint ./src --ext .ts",
         "lint:fix": "eslint ./src --ext .ts --fix",

--- a/templates/ts-crawlee-playwright-chrome/.actor/Dockerfile
+++ b/templates/ts-crawlee-playwright-chrome/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-playwright-chrome:16 AS builder
+FROM apify/actor-node-playwright-chrome:18-1.37.1 AS builder
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.
@@ -19,7 +19,7 @@ COPY --chown=myuser . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node-playwright-chrome:16
+FROM apify/actor-node-playwright-chrome:18-1.37.1
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/templates/ts-crawlee-playwright-chrome/package.json
+++ b/templates/ts-crawlee-playwright-chrome/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "apify": "^3.0.0",
         "crawlee": "^3.0.0",
-        "playwright": "*"
+        "playwright": "1.37.1"
     },
     "devDependencies": {
         "@apify/eslint-config-ts": "^0.2.3",
@@ -23,7 +23,7 @@
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",
-        "start:dev": "ts-node-esm -T src/main.ts",
+        "start:dev": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only src/main.ts",
         "build": "tsc",
         "lint": "eslint ./src --ext .ts",
         "lint:fix": "eslint ./src --ext .ts --fix",

--- a/templates/ts-crawlee-puppeteer-chrome/.actor/Dockerfile
+++ b/templates/ts-crawlee-puppeteer-chrome/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-puppeteer-chrome:16 AS builder
+FROM apify/actor-node-puppeteer-chrome:18 AS builder
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.
@@ -19,7 +19,7 @@ COPY --chown=myuser . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node-puppeteer-chrome:16
+FROM apify/actor-node-puppeteer-chrome:18
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/templates/ts-crawlee-puppeteer-chrome/package.json
+++ b/templates/ts-crawlee-puppeteer-chrome/package.json
@@ -23,7 +23,7 @@
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",
-        "start:dev": "ts-node-esm -T src/main.ts",
+        "start:dev": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only src/main.ts",
         "build": "tsc",
         "lint": "eslint ./src --ext .ts",
         "lint:fix": "eslint ./src --ext .ts --fix",

--- a/templates/ts-empty/package.json
+++ b/templates/ts-empty/package.json
@@ -18,7 +18,7 @@
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",
-        "start:dev": "ts-node-esm -T src/main.ts",
+        "start:dev": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only src/main.ts",
         "build": "tsc",
         "test": "echo \"Error: oops, the actor has no tests yet, sad!\" && exit 1"
     },

--- a/templates/ts-playwright-test-runner/.actor/Dockerfile
+++ b/templates/ts-playwright-test-runner/.actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node-playwright:16
+FROM apify/actor-node-playwright:18-1.37.1
 
 COPY package*.json ./
 

--- a/templates/ts-playwright-test-runner/package.json
+++ b/templates/ts-playwright-test-runner/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@apify/eslint-config-ts": "^0.2.3",
         "@apify/tsconfig": "^0.1.0",
-        "@playwright/test": "^1.30.0",
+        "@playwright/test": "1.37.1",
         "@types/uuid": "^9.0.1",
         "apify": "^3.1.2",
         "ts-node": "^10.9.1",

--- a/templates/ts-start/package.json
+++ b/templates/ts-start/package.json
@@ -19,7 +19,7 @@
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",
-        "start:dev": "ts-node-esm -T src/main.ts",
+        "start:dev": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only src/main.ts",
         "build": "tsc",
         "test": "echo \"Error: oops, the actor has no tests yet, sad!\" && exit 1"
     },


### PR DESCRIPTION
- change `ts-node-esm` to node loader instead to get around https://github.com/TypeStrong/ts-node/issues/1997
- adds node 20 to the CI checks
- use node 18 in all the docker images
- pin playwright dependency (both in package.json and dockerfile) to 1.37.1 as latest version is broken (cannot find the browser)

Closes #167