### PR TITLE
Use HTTPX instead of Requests in Python templates

### DIFF
--- a/templates/python-beautifulsoup/.actor/Dockerfile
+++ b/templates/python-beautifulsoup/.actor/Dockerfile
@@ -3,7 +3,7 @@
 # You can also use any other image from Docker Hub.
 FROM apify/actor-python:3.11
 
-# Second, copy just requirements.txt into the actor image,
+# Second, copy just requirements.txt into the Actor image,
 # since it should be the only file that affects the dependency install in the next step,
 # in order to speed up the build
 COPY requirements.txt ./
@@ -25,6 +25,6 @@ RUN echo "Python version:" \
 # for most source file changes.
 COPY . ./
 
-# Specify how to launch the source code of your actor.
+# Specify how to launch the source code of your Actor.
 # By default, the "python3 -m src" command is run
 CMD ["python3", "-m", "src"]

--- a/templates/python-beautifulsoup/README.md
+++ b/templates/python-beautifulsoup/README.md
@@ -4,8 +4,8 @@ A template for [web scraping](https://apify.com/web-scraping) data from websites
 
 ## Included features
 
-- **[Apify SDK](https://docs.apify.com/sdk/python/)** for Python - a toolkit for building [Actors](https://apify.com/actors) and scrapers in Python
-- **[Input schema](https://docs.apify.com/platform/actors/development/input-schema)** - define and easily validate a schema for your actor's input
+- **[Apify SDK](https://docs.apify.com/sdk/python/)** for Python - a toolkit for building Apify [Actors](https://apify.com/actors) and scrapers in Python
+- **[Input schema](https://docs.apify.com/platform/actors/development/input-schema)** - define and easily validate a schema for your Actor's input
 - **[Request queue](https://docs.apify.com/sdk/python/docs/concepts/storages#working-with-request-queues)** - queues into which you can put the URLs you want to scrape
 - **[Dataset](https://docs.apify.com/sdk/python/docs/concepts/storages#working-with-datasets)** - store structured data where each object stored has the same attributes
 - **[HTTPX](https://www.python-httpx.org)** - library for making asynchronous HTTP requests in Python

--- a/templates/python-beautifulsoup/README.md
+++ b/templates/python-beautifulsoup/README.md
@@ -1,6 +1,6 @@
-## BeautifulSoup and Requests template
+# BeautifulSoup and HTTPX template
 
-A template for [web scraping](https://apify.com/web-scraping) data from websites enqueued from starting URL using Python. The URL of the web page is passed in via input, which is defined by the [input schema](https://docs.apify.com/platform/actors/development/input-schema). The template uses the [Requests](https://requests.readthedocs.io/) to get the HTML of the page and the [Beautiful Soup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/) to parse the data from it. Enqueued URLs are available in [request queue](https://docs.apify.com/sdk/python/reference/class/RequestQueue). The data are then stored in a [dataset](https://docs.apify.com/platform/storage/dataset) where you can easily access them.
+A template for [web scraping](https://apify.com/web-scraping) data from websites enqueued from starting URL using Python. The URL of the web page is passed in via input, which is defined by the [input schema](https://docs.apify.com/platform/actors/development/input-schema). The template uses the [HTTPX](https://www.python-httpx.org) to get the HTML of the page and the [Beautiful Soup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/) to parse the data from it. Enqueued URLs are available in [request queue](https://docs.apify.com/sdk/python/reference/class/RequestQueue). The data are then stored in a [dataset](https://docs.apify.com/platform/storage/dataset) where you can easily access them.
 
 ## Included features
 
@@ -8,16 +8,16 @@ A template for [web scraping](https://apify.com/web-scraping) data from websites
 - **[Input schema](https://docs.apify.com/platform/actors/development/input-schema)** - define and easily validate a schema for your actor's input
 - **[Request queue](https://docs.apify.com/sdk/python/docs/concepts/storages#working-with-request-queues)** - queues into which you can put the URLs you want to scrape
 - **[Dataset](https://docs.apify.com/sdk/python/docs/concepts/storages#working-with-datasets)** - store structured data where each object stored has the same attributes
-- **[Requests](https://requests.readthedocs.io/)** - an elegant and simple HTTP library for Python
+- **[HTTPX](https://www.python-httpx.org)** - library for making asynchronous HTTP requests in Python
 - **[Beautiful Soup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/)** - a Python library for pulling data out of HTML and XML files
 
 ## How it works
 
-This code is a Python script that uses Requests and Beautiful Soup to scrape web pages and extract data from them. Here's a brief overview of how it works:
+This code is a Python script that uses HTTPX and Beautiful Soup to scrape web pages and extract data from them. Here's a brief overview of how it works:
 
 - The script reads the input data from the Actor instance, which is expected to contain a `start_urls` key with a list of URLs to scrape and a `max_depth` key with the maximum depth of nested links to follow.
 - The script enqueues the starting URLs in the default request queue and sets their depth to 0.
-- The script processes the requests in the queue one by one, fetching the URL using Requests and parsing it using BeautifulSoup.
+- The script processes the requests in the queue one by one, fetching the URL using HTTPX and parsing it using BeautifulSoup.
 - If the depth of the current request is less than the maximum depth, the script looks for nested links in the page and enqueues their targets in the request queue with an incremented depth.
 - The script extracts the desired data from the page (in this case, all the links) and pushes it to the default dataset using the `push_data` method of the Actor instance.
 - The script catches any exceptions that occur during the scraping process and logs an error message using the `Actor.log.exception` method.
@@ -26,11 +26,11 @@ This code is a Python script that uses Requests and Beautiful Soup to scrape web
 ## Resources
 
 - [BeautifulSoup Scraper](https://apify.com/apify/beautifulsoup-scraper)
-- [Beautifulsoup Scraper tutorial](https://www.youtube.com/watch?v=1KqLLuIW6MA) 
+- [Beautifulsoup Scraper tutorial](https://www.youtube.com/watch?v=1KqLLuIW6MA)
 - [Python tutorials in Academy](https://docs.apify.com/academy/python)
 - [Web scraping with Beautiful Soup and Requests](https://blog.apify.com/web-scraping-with-beautiful-soup/)
 - [Beautiful Soup vs. Scrapy for web scraping](https://blog.apify.com/beautiful-soup-vs-scrapy-web-scraping/)
-- [Integration with Zapier](https://apify.com/integrations), Make, Google Drive, and others
+- [Integration with Make, GitHub, Zapier, Google Drive, and other apps](https://apify.com/integrations)
 - [Video guide on getting scraped data using Apify API](https://www.youtube.com/watch?v=ViYYDHSBAKM)
 - [Video introduction to Python SDK](https://www.youtube.com/watch?v=C8DmvJQS3jk)
 

--- a/templates/python-beautifulsoup/requirements.txt
+++ b/templates/python-beautifulsoup/requirements.txt
@@ -2,5 +2,5 @@
 # See https://pip.pypa.io/en/latest/reference/requirements-file-format/
 # for how to format them
 apify ~= 1.1.5
-beautifulsoup4 ~= 4.12.0
-requests ~= 2.31.0
+beautifulsoup4 ~= 4.12.2
+httpx ~= 0.25.0

--- a/templates/python-empty/.actor/Dockerfile
+++ b/templates/python-empty/.actor/Dockerfile
@@ -3,7 +3,7 @@
 # You can also use any other image from Docker Hub.
 FROM apify/actor-python:3.11
 
-# Second, copy just requirements.txt into the actor image,
+# Second, copy just requirements.txt into the Actor image,
 # since it should be the only file that affects the dependency install in the next step,
 # in order to speed up the build
 COPY requirements.txt ./
@@ -25,6 +25,6 @@ RUN echo "Python version:" \
 # for most source file changes.
 COPY . ./
 
-# Specify how to launch the source code of your actor.
+# Specify how to launch the source code of your Actor.
 # By default, the "python3 -m ." command is run
 CMD ["python3", "-m", "src"]

--- a/templates/python-empty/README.md
+++ b/templates/python-empty/README.md
@@ -1,21 +1,22 @@
-## Empty Python template
+# Empty Python template
 
 Start a new [web scraping](https://apify.com/web-scraping) project quickly and easily in Python with our empty project template. It provides a basic structure for the [Actor](https://apify.com/actors) with [Apify SDK](https://docs.apify.com/sdk/python/) and allows you to easily add your own functionality.
 
 ## Included features
 
 - **[Apify SDK](https://docs.apify.com/sdk/python/)** for Python - a toolkit for building [Actors](https://apify.com/actors) and scrapers in Python
-- **[Beautiful Soup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/)** - library for pulling data out of HTML and XML files
+- **[Input schema](https://docs.apify.com/platform/actors/development/input-schema)** - define and easily validate a schema for your Actor's input
+- **[Dataset](https://docs.apify.com/sdk/js/docs/guides/result-storage#dataset)** - store structured data where each object stored has the same attributes
 
 ## How it works
 
-Insert your own code to `async with Actor:` block. You can use the [Apify SDK](https://docs.apify.com/sdk/python/), [Beautiful Soup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/) or any other Python library.
+Insert your own code to `async with Actor:` block. You can use the [Apify SDK](https://docs.apify.com/sdk/python/) with any other Python library.
 
 ## Resources
 
 - [Python tutorials in Academy](https://docs.apify.com/academy/python)
 - [Video guide on getting data using Apify API](https://www.youtube.com/watch?v=ViYYDHSBAKM)
-- [Integration with Make](https://apify.com/integrations), GitHub, Zapier, Google Drive, and other apps
+- [Integration with Make, GitHub, Zapier, Google Drive, and other apps](https://apify.com/integrations)
 
 **A short guide on how to build web scrapers using code templates:**
 [web scraper template](https://www.youtube.com/watch?v=u-i-Korzf8w)

--- a/templates/python-empty/README.md
+++ b/templates/python-empty/README.md
@@ -4,9 +4,10 @@ Start a new [web scraping](https://apify.com/web-scraping) project quickly and e
 
 ## Included features
 
-- **[Apify SDK](https://docs.apify.com/sdk/python/)** for Python - a toolkit for building [Actors](https://apify.com/actors) and scrapers in Python
+- **[Apify SDK](https://docs.apify.com/sdk/python/)** for Python - a toolkit for building Apify [Actors](https://apify.com/actors) and scrapers in Python
 - **[Input schema](https://docs.apify.com/platform/actors/development/input-schema)** - define and easily validate a schema for your Actor's input
-- **[Dataset](https://docs.apify.com/sdk/js/docs/guides/result-storage#dataset)** - store structured data where each object stored has the same attributes
+- **[Request queue](https://docs.apify.com/sdk/python/docs/concepts/storages#working-with-request-queues)** - queues into which you can put the URLs you want to scrape
+- **[Dataset](https://docs.apify.com/sdk/python/docs/concepts/storages#working-with-datasets)** - store structured data where each object stored has the same attributes
 
 ## How it works
 

--- a/templates/python-empty/requirements.txt
+++ b/templates/python-empty/requirements.txt
@@ -1,2 +1,1 @@
 apify ~= 1.1.5
-beautifulsoup4 ~= 4.12.0

--- a/templates/python-empty/src/main.py
+++ b/templates/python-empty/src/main.py
@@ -1,13 +1,8 @@
-# Beautiful Soup - library for pulling data out of HTML and XML files (Read more at https://www.crummy.com/software/BeautifulSoup/bs4/doc/)
-# from bs4 import BeautifulSoup
-
 # Apify SDK - toolkit for building Apify Actors (Read more at https://docs.apify.com/sdk/python)
 from apify import Actor
 
 
 async def main():
     async with Actor:
-        print('Hello from the Actor!')
-        """
-        Actor code
-        """
+        Actor.log.info('Hello from the Actor!')
+        # Write your code here

--- a/templates/python-playwright/.actor/Dockerfile
+++ b/templates/python-playwright/.actor/Dockerfile
@@ -3,7 +3,7 @@
 # You can also use any other image from Docker Hub.
 FROM apify/actor-python-playwright:3.11
 
-# Second, copy just requirements.txt into the actor image,
+# Second, copy just requirements.txt into the Actor image,
 # since it should be the only file that affects the dependency install in the next step,
 # in order to speed up the build
 COPY requirements.txt ./
@@ -25,6 +25,6 @@ RUN echo "Python version:" \
 # for most source file changes.
 COPY . ./
 
-# Specify how to launch the source code of your actor.
+# Specify how to launch the source code of your Actor.
 # By default, the "python3 -m src" command is run
 CMD ["python3", "-m", "src"]

--- a/templates/python-playwright/README.md
+++ b/templates/python-playwright/README.md
@@ -2,10 +2,11 @@
 
 ## Included features
 
-- **[Apify SDK](https://docs.apify.com/sdk/python/)** for Python - toolkit for building Apify [Actors](https://apify.com/actors) and scrapers in Python
+- **[Apify SDK](https://docs.apify.com/sdk/python/)** for Python - a toolkit for building Apify [Actors](https://apify.com/actors) and scrapers in Python
 - **[Input schema](https://docs.apify.com/platform/actors/development/input-schema)** - define and easily validate a schema for your Actor's input
+- **[Request queue](https://docs.apify.com/sdk/python/docs/concepts/storages#working-with-request-queues)** - queues into which you can put the URLs you want to scrape
 - **[Dataset](https://docs.apify.com/sdk/python/docs/concepts/storages#working-with-datasets)** - store structured data where each object stored has the same attributes
-- Playwright - a browser automation library
+- **[Playwright](https://pypi.org/project/playwright/)** - a browser automation library
 
 ## Resources
 

--- a/templates/python-scrapy/.actor/Dockerfile
+++ b/templates/python-scrapy/.actor/Dockerfile
@@ -3,7 +3,7 @@
 # You can also use any other image from Docker Hub.
 FROM apify/actor-python:3.11
 
-# Second, copy just requirements.txt into the actor image,
+# Second, copy just requirements.txt into the Actor image,
 # since it should be the only file that affects the dependency install in the next step,
 # in order to speed up the build
 COPY requirements.txt ./
@@ -25,6 +25,6 @@ RUN echo "Python version:" \
 # for most source file changes.
 COPY . ./
 
-# Specify how to launch the source code of your actor.
+# Specify how to launch the source code of your Actor.
 # By default, the "python3 -m src" command is run
 CMD ["python3", "-m", "src"]

--- a/templates/python-scrapy/README.md
+++ b/templates/python-scrapy/README.md
@@ -6,6 +6,7 @@ A template example built with Scrapy to scrape page titles from URLs defined in 
 
 - **[Apify SDK](https://docs.apify.com/sdk/python/)** for Python - a toolkit for building Apify [Actors](https://apify.com/actors) and scrapers in Python
 - **[Input schema](https://docs.apify.com/platform/actors/development/input-schema)** - define and easily validate a schema for your Actor's input
+- **[Request queue](https://docs.apify.com/sdk/python/docs/concepts/storages#working-with-request-queues)** - queues into which you can put the URLs you want to scrape
 - **[Dataset](https://docs.apify.com/sdk/python/docs/concepts/storages#working-with-datasets)** - store structured data where each object stored has the same attributes
 - **[Scrapy](https://scrapy.org/)** - a fast high-level web scraping framework
 

--- a/templates/python-selenium/.actor/Dockerfile
+++ b/templates/python-selenium/.actor/Dockerfile
@@ -3,7 +3,7 @@
 # You can also use any other image from Docker Hub.
 FROM apify/actor-python-selenium:3.11
 
-# Second, copy just requirements.txt into the actor image,
+# Second, copy just requirements.txt into the Actor image,
 # since it should be the only file that affects the dependency install in the next step,
 # in order to speed up the build
 COPY requirements.txt ./
@@ -25,6 +25,6 @@ RUN echo "Python version:" \
 # for most source file changes.
 COPY . ./
 
-# Specify how to launch the source code of your actor.
+# Specify how to launch the source code of your Actor.
 # By default, the "python3 -m src" command is run
 CMD ["python3", "-m", "src"]

--- a/templates/python-selenium/README.md
+++ b/templates/python-selenium/README.md
@@ -8,6 +8,7 @@ A template example built with Selenium and a headless Chrome browser to scrape a
 - **[Input schema](https://docs.apify.com/platform/actors/development/input-schema)** - define and easily validate a schema for your Actor's input
 - **[Request queue](https://docs.apify.com/sdk/python/docs/concepts/storages#working-with-request-queues)** - queues into which you can put the URLs you want to scrape
 - **[Dataset](https://docs.apify.com/sdk/python/docs/concepts/storages#working-with-datasets)** - store structured data where each object stored has the same attributes
+- **[Selenium](https://pypi.org/project/selenium/)** - a browser automation library
 
 ## How it works
 

--- a/templates/python-start/.actor/Dockerfile
+++ b/templates/python-start/.actor/Dockerfile
@@ -3,7 +3,7 @@
 # You can also use any other image from Docker Hub.
 FROM apify/actor-python:3.11
 
-# Second, copy just requirements.txt into the actor image,
+# Second, copy just requirements.txt into the Actor image,
 # since it should be the only file that affects the dependency install in the next step,
 # in order to speed up the build
 COPY requirements.txt ./
@@ -25,6 +25,6 @@ RUN echo "Python version:" \
 # for most source file changes.
 COPY . ./
 
-# Specify how to launch the source code of your actor.
+# Specify how to launch the source code of your Actor.
 # By default, the "python3 -m src" command is run
 CMD ["python3", "-m", "src"]

--- a/templates/python-start/README.md
+++ b/templates/python-start/README.md
@@ -1,14 +1,15 @@
 # Scrape single-page in Python template
 
-A template for [web scraping](https://apify.com/web-scraping) data from a single web page in Python. The URL of the web page is passed in via input, which is defined by the [input schema](https://docs.apify.com/platform/actors/development/input-schema). The template uses the [HTTPX](https://www.python-httpx.org) to get the HTML of the page and the [Beautiful Soup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/) to parse the data from it. The data are then stored in a [dataset](https://docs.apify.com/sdk/js/docs/guides/result-storage#dataset) where you can easily access them.
+A template for [web scraping](https://apify.com/web-scraping) data from a single web page in Python. The URL of the web page is passed in via input, which is defined by the [input schema](https://docs.apify.com/platform/actors/development/input-schema). The template uses the [HTTPX](https://www.python-httpx.org) to get the HTML of the page and the [Beautiful Soup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/) to parse the data from it. The data are then stored in a [dataset](https://docs.apify.com/sdk/python/docs/concepts/storages#working-with-datasets) where you can easily access them.
 
 The scraped data in this template are page headings but you can easily edit the code to scrape whatever you want from the page.
 
 ## Included features
 
-- **[Apify SDK](https://docs.apify.com/sdk/js/)** for Python - a toolkit for building [Actors](https://apify.com/actors) and scrapers in Python
+- **[Apify SDK](https://docs.apify.com/sdk/python/)** for Python - a toolkit for building Apify [Actors](https://apify.com/actors) and scrapers in Python
 - **[Input schema](https://docs.apify.com/platform/actors/development/input-schema)** - define and easily validate a schema for your Actor's input
-- **[Dataset](https://docs.apify.com/sdk/js/docs/guides/result-storage#dataset)** - store structured data where each object stored has the same attributes
+- **[Request queue](https://docs.apify.com/sdk/python/docs/concepts/storages#working-with-request-queues)** - queues into which you can put the URLs you want to scrape
+- **[Dataset](https://docs.apify.com/sdk/python/docs/concepts/storages#working-with-datasets)** - store structured data where each object stored has the same attributes
 - **[HTTPX](https://www.python-httpx.org)** - library for making asynchronous HTTP requests in Python
 - **[Beautiful Soup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/)** - library for pulling data out of HTML and XML files
 

--- a/templates/python-start/README.md
+++ b/templates/python-start/README.md
@@ -1,6 +1,6 @@
-## Scrape single-page in Python template
+# Scrape single-page in Python template
 
-A template for [web scraping](https://apify.com/web-scraping) data from a single web page in Python. The URL of the web page is passed in via input, which is defined by the [input schema](https://docs.apify.com/platform/actors/development/input-schema). The template uses the [Requests](https://requests.readthedocs.io/) to get the HTML of the page and the [Beautiful Soup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/) to parse the data from it. The data are then stored in a [dataset](https://docs.apify.com/sdk/js/docs/guides/result-storage#dataset) where you can easily access them.
+A template for [web scraping](https://apify.com/web-scraping) data from a single web page in Python. The URL of the web page is passed in via input, which is defined by the [input schema](https://docs.apify.com/platform/actors/development/input-schema). The template uses the [HTTPX](https://www.python-httpx.org) to get the HTML of the page and the [Beautiful Soup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/) to parse the data from it. The data are then stored in a [dataset](https://docs.apify.com/sdk/js/docs/guides/result-storage#dataset) where you can easily access them.
 
 The scraped data in this template are page headings but you can easily edit the code to scrape whatever you want from the page.
 
@@ -9,21 +9,18 @@ The scraped data in this template are page headings but you can easily edit the 
 - **[Apify SDK](https://docs.apify.com/sdk/js/)** for Python - a toolkit for building [Actors](https://apify.com/actors) and scrapers in Python
 - **[Input schema](https://docs.apify.com/platform/actors/development/input-schema)** - define and easily validate a schema for your Actor's input
 - **[Dataset](https://docs.apify.com/sdk/js/docs/guides/result-storage#dataset)** - store structured data where each object stored has the same attributes
-- **[Requests](https://requests.readthedocs.io/)** - library for making HTTP requests in Python
+- **[HTTPX](https://www.python-httpx.org)** - library for making asynchronous HTTP requests in Python
 - **[Beautiful Soup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/)** - library for pulling data out of HTML and XML files
 
 ## How it works
 
 1. `Actor.get_input()` gets the input where the page URL is defined
-2. `requests.get(url)` fetches the page
+2. `httpx.AsyncClient().get(url)` fetches the page
 3. `BeautifulSoup(response.content, 'html.parser')` loads the page data and enables parsing the headings
 4. This parses the headings from the page and here you can edit the code to parse whatever you need from the page
-    
     ```python
     for heading in soup.find_all(["h1", "h2", "h3", "h4", "h5", "h6"]):
-    
     ```
-    
 5. `Actor.push_data(headings)` stores the headings in the dataset
 
 ## Resources
@@ -32,9 +29,8 @@ The scraped data in this template are page headings but you can easily edit the 
 - [Python tutorials in Academy](https://docs.apify.com/academy/python)
 - [Web scraping with Beautiful Soup and Requests](https://blog.apify.com/web-scraping-with-beautiful-soup/)
 - [Beautiful Soup vs. Scrapy for web scraping](https://blog.apify.com/beautiful-soup-vs-scrapy-web-scraping/)
-- [Integration with Zapier](https://apify.com/integrations), Make, Google Drive, and others
+- [Integration with Make, GitHub, Zapier, Google Drive, and other apps](https://apify.com/integrations)
 - [Video guide on getting scraped data using Apify API](https://www.youtube.com/watch?v=ViYYDHSBAKM)
 
 **A short guide on how to build web scrapers using code templates:**
 [web scraper template](https://www.youtube.com/watch?v=u-i-Korzf8w)
-

--- a/templates/python-start/requirements.txt
+++ b/templates/python-start/requirements.txt
@@ -2,5 +2,5 @@
 # See https://pip.pypa.io/en/latest/reference/requirements-file-format/
 # for how to format them
 apify ~= 1.1.5
-beautifulsoup4 ~= 4.12.0
-requests ~= 2.31.0
+beautifulsoup4 ~= 4.12.2
+httpx ~= 0.25.0

--- a/templates/python-start/src/main.py
+++ b/templates/python-start/src/main.py
@@ -1,9 +1,9 @@
-# Requests - library for making HTTP requests in Python (Read more at https://requests.readthedocs.io)
-import requests
 # Beautiful Soup - library for pulling data out of HTML and XML files (Read more at https://www.crummy.com/software/BeautifulSoup/bs4/doc)
 from bs4 import BeautifulSoup
+# HTTPX - library for making asynchronous HTTP requests in Python (Read more at https://www.python-httpx.org/)
+from httpx import AsyncClient
 
-# Apify SDK - toolkit for building Apify Actors (Read more at https://docs.apify.com/sdk/python).
+# Apify SDK - toolkit for building Apify Actors (Read more at https://docs.apify.com/sdk/python)
 from apify import Actor
 
 
@@ -13,18 +13,20 @@ async def main():
         actor_input = await Actor.get_input() or {}
         url = actor_input.get('url')
 
-        # Fetch the HTML content of the page.
-        response = requests.get(url)
+        # Create an asynchronous HTTPX client
+        async with AsyncClient() as client:
+            # Fetch the HTML content of the page.
+            response = await client.get(url)
 
-        # Parse the HTML content using Beautiful Soup.
+        # Parse the HTML content using Beautiful Soup
         soup = BeautifulSoup(response.content, 'html.parser')
 
-        # Extract all headings from the page (tag name and text).
+        # Extract all headings from the page (tag name and text)
         headings = []
         for heading in soup.find_all(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']):
             heading_object = {'level': heading.name, 'text': heading.text}
-            print('Extracted heading', heading_object)
+            Actor.log.info(f'Extracted heading: {heading_object}')
             headings.append(heading_object)
 
-        # Save headings to Dataset - a table-like storage.
+        # Save headings to Dataset - a table-like storage
         await Actor.push_data(headings)


### PR DESCRIPTION
### Issue
- https://github.com/apify/actor-templates/issues/182
The motivation for usage of HTTPX is explained here: https://github.com/apify/actor-templates/issues/182#issuecomment-1748615100.

### Description
- All the templates that were using Requests (`python-beautifulsoup`, `python-start`) now use HTTPX.
    - I also updated relevant texts in the readmes and in the code comments. 
- On top of that...
    - I removed `beautifulsoup` from the `requirements.txt` of `python-empty` template (it was not used there).
    - `actor` -> `Actor`
    - Fix a few broken/wrong links (e.g. to JS instead of Python docs)
    - Some unification of `## Included features` section in the README across all the Python Actors