### PR TITLE
Scrapy Actor: Update ActorDatasetPushPipeline from 1 to 1000

### DIFF
--- a/templates/python-scrapy/src/main.py
+++ b/templates/python-scrapy/src/main.py
@@ -66,16 +66,21 @@ def _get_scrapy_settings(max_depth: int) -> Settings:
         Scrapy project settings with custom configurations.
     """
     settings = get_project_settings()
-    # Add Apify Actor dataset push pipeline with the lowest priority
-    settings['ITEM_PIPELINES']['apify.scrapy.pipelines.ActorDatasetPushPipeline'] = 1
-    # Disable default retry middleware
+
+    # Add the ActorDatasetPushPipeline into the item pipelines, assigning it the highest integer (1000),
+    # ensuring it is executed as the final step in the pipeline sequence
+    settings['ITEM_PIPELINES']['apify.scrapy.pipelines.ActorDatasetPushPipeline'] = 1000
+
+    # Disable the default RetryMiddleware and add ApifyRetryMiddleware with the highest integer (1000)
     settings['DOWNLOADER_MIDDLEWARES']['scrapy.downloadermiddlewares.retry.RetryMiddleware'] = None
-    # Add Apify custom retry middleware with the top priority
-    settings['DOWNLOADER_MIDDLEWARES']['apify.scrapy.middlewares.ApifyRetryMiddleware'] = 999
-    # Add Apify custom scheduler
+    settings['DOWNLOADER_MIDDLEWARES']['apify.scrapy.middlewares.ApifyRetryMiddleware'] = 1000
+
+    # Use ApifyScheduler as the scheduler
     settings['SCHEDULER'] = 'apify.scrapy.scheduler.ApifyScheduler'
-    # Set the maximum depth for spider crawling
+
+    # Specify the maximum depth for spider crawling
     settings['DEPTH_LIMIT'] = max_depth
+
     return settings
 
 

--- a/wrappers/python-scrapy/{projectFolder}/main.template.py
+++ b/wrappers/python-scrapy/{projectFolder}/main.template.py
@@ -66,16 +66,21 @@ def _get_scrapy_settings(max_depth: int) -> Settings:
         Scrapy project settings with custom configurations.
     """
     settings = get_project_settings()
-    # Add Apify Actor dataset push pipeline with the lowest priority
-    settings['ITEM_PIPELINES']['apify.scrapy.pipelines.ActorDatasetPushPipeline'] = 1
-    # Disable default retry middleware
+
+    # Add the ActorDatasetPushPipeline into the item pipelines, assigning it the highest integer (1000),
+    # ensuring it is executed as the final step in the pipeline sequence
+    settings['ITEM_PIPELINES']['apify.scrapy.pipelines.ActorDatasetPushPipeline'] = 1000
+
+    # Disable the default RetryMiddleware and add ApifyRetryMiddleware with the highest integer (1000)
     settings['DOWNLOADER_MIDDLEWARES']['scrapy.downloadermiddlewares.retry.RetryMiddleware'] = None
-    # Add Apify custom retry middleware with the top priority
-    settings['DOWNLOADER_MIDDLEWARES']['apify.scrapy.middlewares.ApifyRetryMiddleware'] = 999
-    # Add Apify custom scheduler
+    settings['DOWNLOADER_MIDDLEWARES']['apify.scrapy.middlewares.ApifyRetryMiddleware'] = 1000
+
+    # Use ApifyScheduler as the scheduler
     settings['SCHEDULER'] = 'apify.scrapy.scheduler.ApifyScheduler'
-    # Set the maximum depth for spider crawling
+
+    # Specify the maximum depth for spider crawling
     settings['DEPTH_LIMIT'] = max_depth
+
     return settings
 
 


### PR DESCRIPTION
While testing the Scrapy wrapper, I encountered a bug where the `ActorDatasetPushPipeline` with a priority number of 1 is being executed first. This makes all other item pipelines essentially useless. It should ideally be executed as the last one to perform all the necessary cleaning processes before storing the data.

From Scrapy docs (https://docs.scrapy.org/en/latest/topics/item-pipeline.html#activating-an-item-pipeline-component):
> The integer values you assign to classes in this setting determine the order in which they run: items go through from lower valued to higher valued classes. It’s customary to define these numbers in the 0-1000 range.

