### PR TITLE
chore: move to tsx for templates from ts-node

### DIFF
--- a/templates/ts-bootstrap-cheerio-crawler/package.json
+++ b/templates/ts-bootstrap-cheerio-crawler/package.json
@@ -16,13 +16,13 @@
         "@typescript-eslint/eslint-plugin": "^6.7.2",
         "@typescript-eslint/parser": "^6.7.2",
         "eslint": "^8.50.0",
-        "ts-node": "^10.9.1",
-        "typescript": "~5.2.2"
+        "tsx": "^4.6.2",
+        "typescript": "^5.3.3"
     },
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",
-        "start:dev": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only src/main.ts",
+        "start:dev": "tsx src/main.ts",
         "build": "tsc",
         "lint": "eslint ./src --ext .ts",
         "lint:fix": "eslint ./src --ext .ts --fix",

--- a/templates/ts-crawlee-cheerio/package.json
+++ b/templates/ts-crawlee-cheerio/package.json
@@ -16,13 +16,13 @@
         "@typescript-eslint/eslint-plugin": "^6.7.2",
         "@typescript-eslint/parser": "^6.7.2",
         "eslint": "^8.50.0",
-        "ts-node": "^10.9.1",
-        "typescript": "~5.2.2"
+        "tsx": "^4.6.2",
+        "typescript": "^5.3.3"
     },
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",
-        "start:dev": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only src/main.ts",
+        "start:dev": "tsx src/main.ts",
         "build": "tsc",
         "lint": "eslint ./src --ext .ts",
         "lint:fix": "eslint ./src --ext .ts --fix",

--- a/templates/ts-crawlee-playwright-chrome/package.json
+++ b/templates/ts-crawlee-playwright-chrome/package.json
@@ -17,13 +17,13 @@
         "@typescript-eslint/eslint-plugin": "^6.7.2",
         "@typescript-eslint/parser": "^6.7.2",
         "eslint": "^8.50.0",
-        "ts-node": "^10.9.1",
-        "typescript": "~5.2.2"
+        "tsx": "^4.6.2",
+        "typescript": "^5.3.3"
     },
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",
-        "start:dev": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only src/main.ts",
+        "start:dev": "tsx src/main.ts",
         "build": "tsc",
         "lint": "eslint ./src --ext .ts",
         "lint:fix": "eslint ./src --ext .ts --fix",

--- a/templates/ts-crawlee-puppeteer-chrome/package.json
+++ b/templates/ts-crawlee-puppeteer-chrome/package.json
@@ -17,13 +17,13 @@
         "@typescript-eslint/eslint-plugin": "^6.7.2",
         "@typescript-eslint/parser": "^6.7.2",
         "eslint": "^8.50.0",
-        "ts-node": "^10.9.1",
-        "typescript": "~5.2.2"
+        "tsx": "^4.6.2",
+        "typescript": "^5.3.3"
     },
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",
-        "start:dev": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only src/main.ts",
+        "start:dev": "tsx src/main.ts",
         "build": "tsc",
         "lint": "eslint ./src --ext .ts",
         "lint:fix": "eslint ./src --ext .ts --fix",

--- a/templates/ts-empty/package.json
+++ b/templates/ts-empty/package.json
@@ -12,13 +12,13 @@
     },
     "devDependencies": {
         "@apify/tsconfig": "^0.1.0",
-        "ts-node": "^10.9.1",
-        "typescript": "~5.2.2"
+        "tsx": "^4.6.2",
+        "typescript": "^5.3.3"
     },
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",
-        "start:dev": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only src/main.ts",
+        "start:dev": "tsx src/main.ts",
         "build": "tsc",
         "test": "echo \"Error: oops, the actor has no tests yet, sad!\" && exit 1"
     },

--- a/templates/ts-playwright-test-runner/package.json
+++ b/templates/ts-playwright-test-runner/package.json
@@ -5,9 +5,9 @@
     "main": "src/index.ts",
     "scripts": {
         "start": "npm run start:dev",
-        "start:dev": "ts-node src/main.ts",
+        "start:dev": "tsx src/main.ts",
         "start:prod": "node dist/main.js",
-        "codegen": "ts-node src/runCodegen.ts",
+        "codegen": "tsx src/runCodegen.ts",
         "build": "tsc",
         "test": "echo \"Error: no test specified\" && exit 1",
         "postinstall": "npx crawlee install-playwright-browsers"
@@ -21,8 +21,8 @@
         "@playwright/test": "1.37.1",
         "@types/uuid": "^9.0.4",
         "apify": "^3.1.10",
-        "ts-node": "^10.9.1",
-        "typescript": "~5.2.2",
+        "tsx": "^4.6.2",
+        "typescript": "^5.3.3",
         "uuid": "^9.0.1"
     }
 }

--- a/templates/ts-start/package.json
+++ b/templates/ts-start/package.json
@@ -13,13 +13,13 @@
     },
     "devDependencies": {
         "@apify/tsconfig": "^0.1.0",
-        "ts-node": "^10.9.1",
-        "typescript": "~5.2.2"
+        "tsx": "^4.6.2",
+        "typescript": "^5.3.3"
     },
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",
-        "start:dev": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only src/main.ts",
+        "start:dev": "tsx src/main.ts",
         "build": "tsc",
         "test": "echo \"Error: oops, the actor has no tests yet, sad!\" && exit 1"
     },

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -50,7 +50,7 @@ const canNodeTemplateRun = (templateId) => {
     const requiredBunVersion = packageJson.engines?.bun;
 
     if (requiredBunVersion && !requiredNodeVersion) {
-        console.log(`Skipping ${templateId} because it can only be run unsing bun.`);
+        console.log(`Skipping ${templateId} because it can only be run using bun.`);
         return false;
     }
 


### PR DESCRIPTION
Also unlocks TypeScript 5.3

---

Unrelated, but the code in `templates.test.js` looks wrong:

![Code - 2023-12-11 at 13 55 25](https://github.com/apify/actor-templates/assets/17960496/2cf08173-fa63-404d-9cae-380eb896d36b)

I'm not gonna touch it in this PR but this is something to keep in mind.