### PR TITLE
Fixed init for `js-crawlee-playwright-chrome` and dynamic input fro `ts-crawlee-playwright-chrome` template

### DIFF
--- a/templates/js-crawlee-playwright-chrome/src/main.js
+++ b/templates/js-crawlee-playwright-chrome/src/main.js
@@ -13,6 +13,8 @@ import { PlaywrightCrawler } from 'crawlee';
 import { router } from './routes.js';
 
 // Initialize the Apify SDK
+await Actor.init();
+
 const {
     startUrls = ['https://crawlee.dev'],
 } = await Actor.getInput() ?? {};

--- a/templates/ts-crawlee-playwright-chrome/.actor/input_schema.json
+++ b/templates/ts-crawlee-playwright-chrome/.actor/input_schema.json
@@ -10,9 +10,15 @@
             "editor": "requestListSources",
             "prefill": [
                 {
-                    "url": "https://apify.com"
+                    "url": "https://crawlee.dev"
                 }
             ]
+        },
+        "maxRequestsPerCrawl": {
+            "title": "Max Requests per Crawl",
+            "type": "integer",
+            "description": "Maximum number of requests that can be made by this crawler.",
+            "default": 100
         }
     }
 }

--- a/templates/ts-crawlee-playwright-chrome/src/main.ts
+++ b/templates/ts-crawlee-playwright-chrome/src/main.ts
@@ -13,15 +13,25 @@ import { PlaywrightCrawler } from 'crawlee';
 // note that we need to use `.js` even when inside TS files
 import { router } from './routes.js';
 
+interface Input {
+    startUrls: string[];
+    maxRequestsPerCrawl: number;
+}
+
 // Initialize the Apify SDK
 await Actor.init();
 
-const startUrls = ['https://apify.com'];
+// Structure of input is defined in input_schema.json
+const {
+    startUrls = ['https://crawlee.dev'],
+    maxRequestsPerCrawl = 100,
+} = await Actor.getInput<Input>() ?? {} as Input;
 
 const proxyConfiguration = await Actor.createProxyConfiguration();
 
 const crawler = new PlaywrightCrawler({
     proxyConfiguration,
+    maxRequestsPerCrawl,
     requestHandler: router,
 });
 


### PR DESCRIPTION
- Added missing `Actor.init()` at the top of the template code for `js-crawlee-playwright-chrome` template
- Switched `ts-crawlee-playwright-chrome` to a template with dynamic input URLs (we probably forgot to switch it while doing updates for the templates)

Reported in Slack #bugs channel https://apifier.slack.com/archives/C0L33UM7Z/p1705144932648779