### PR TITLE
chore: add in rudimentary typings

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 templates
+src/*.d.[cm]ts

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.4",
     "description": "A manifest of Apify actor templates.",
     "main": "src/index.js",
-    "types": "src/index.d.ts",
+    "types": "src/index.d.cts",
     "exports": {
         "import": {
             "types": "./src/index.d.mts",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,20 @@
     "version": "0.1.4",
     "description": "A manifest of Apify actor templates.",
     "main": "src/index.js",
+    "types": "src/index.d.ts",
+    "exports": {
+        "import": {
+            "types": "./src/index.d.mts",
+            "default": "./src/index.js"
+        },
+        "require": {
+            "types": "./src/index.d.cts",
+            "default": "./src/index.js"
+        }
+    },
     "files": [
-        "src/index.js"
+        "src/index.js",
+        "src/index.d.*"
     ],
     "scripts": {
         "lint": "eslint . --ext .js,.ts",

--- a/src/index.d.cts
+++ b/src/index.d.cts
@@ -1,0 +1,31 @@
+export interface Template {
+    id: string;
+    name: string;
+    label: string;
+    category: string;
+    technologies: string[];
+    description: string;
+    messages?: {
+        postCreate?: string;
+    };
+    archiveUrl: string;
+    defaultRunOptions?: {
+
+        build?: string;
+        memoryMbytes?: number;
+        timeoutSecs?: number;
+    };
+    showcaseFiles?: string[];
+    useCases?: string[];
+    aliases?: string[];
+}
+
+export interface Manifest {
+    consoleReadmeSuffixUrl?: string;
+    localReadmeSuffixUrl?: string;
+    templates: Template[];
+}
+
+export function fetchManifest(manifestUrl?: string): Promise<Manifest>;
+export const manifestUrl: string;
+export const wrapperManifestUrl: string;

--- a/src/index.d.mts
+++ b/src/index.d.mts
@@ -1,0 +1,31 @@
+export interface Template {
+    id: string;
+    name: string;
+    label: string;
+    category: string;
+    technologies: string[];
+    description: string;
+    messages?: {
+        postCreate?: string;
+    };
+    archiveUrl: string;
+    defaultRunOptions?: {
+
+        build?: string;
+        memoryMbytes?: number;
+        timeoutSecs?: number;
+    };
+    showcaseFiles?: string[];
+    useCases?: string[];
+    aliases?: string[];
+}
+
+export interface Manifest {
+    consoleReadmeSuffixUrl?: string;
+    localReadmeSuffixUrl?: string;
+    templates: Template[];
+}
+
+export function fetchManifest(manifestUrl?: string): Promise<Manifest>;
+export const manifestUrl: string;
+export const wrapperManifestUrl: string;


### PR DESCRIPTION
This module is used externally to fetch the manifests, and TS types are always nice to have

Result: (for this its fineee if its masquerading as ESM, as we use esm-compatible syntax)
![Google Chrome Beta - 2024-02-08 at 18 39 57@2x](https://github.com/apify/actor-templates/assets/17960496/cf8a534d-fcca-42e5-9cd6-9dc2dc855c13)
