### PR TITLE
chore: update version requirements for python sdk

### DIFF
--- a/templates/python-beautifulsoup/requirements.txt
+++ b/templates/python-beautifulsoup/requirements.txt
@@ -1,7 +1,7 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify ~= 1.6.0
+apify ~= 1.7.0
 beautifulsoup4 ~= 4.12.2
 httpx ~= 0.25.2
 types-beautifulsoup4 ~= 4.12.0.7

--- a/templates/python-empty/requirements.txt
+++ b/templates/python-empty/requirements.txt
@@ -1,4 +1,4 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify ~= 1.6.0
+apify ~= 1.7.0

--- a/templates/python-playwright/requirements.txt
+++ b/templates/python-playwright/requirements.txt
@@ -1,5 +1,5 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify ~= 1.6.0
+apify ~= 1.7.0
 playwright ~= 1.39.0

--- a/templates/python-scrapy/requirements.txt
+++ b/templates/python-scrapy/requirements.txt
@@ -1,6 +1,6 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify[scrapy] ~= 1.6.0
+apify[scrapy] ~= 1.7.0
 nest-asyncio ~= 1.5.8
 scrapy ~= 2.11.1

--- a/templates/python-selenium/requirements.txt
+++ b/templates/python-selenium/requirements.txt
@@ -1,5 +1,5 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify ~= 1.6.0
+apify ~= 1.7.0
 selenium ~= 4.14.0

--- a/templates/python-start/requirements.txt
+++ b/templates/python-start/requirements.txt
@@ -1,7 +1,7 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify ~= 1.6.0
+apify ~= 1.7.0
 beautifulsoup4 ~= 4.12.2
 httpx ~= 0.25.2
 types-beautifulsoup4 ~= 4.12.0.7

--- a/wrappers/python-scrapy/requirements_apify.txt
+++ b/wrappers/python-scrapy/requirements_apify.txt
@@ -1,6 +1,6 @@
 # Add your dependencies here.
 # See https://pip.pypa.io/en/latest/reference/requirements-file-format/
 # for how to format them
-apify[scrapy] ~= 1.6.0
+apify[scrapy] ~= 1.7.0
 nest-asyncio ~= 1.5.8
 scrapy ~= 2.11.1


### PR DESCRIPTION
This should fix the failing tests. We might want to make the requirements looser and just install the latest version.