### PR TITLE
chore: update Node.js 18 -> 20 in all templates

### DIFF
--- a/templates/js-bootstrap-cheerio-crawler/.actor/Dockerfile
+++ b/templates/js-bootstrap-cheerio-crawler/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # See https://docs.apify.com/sdk/js/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:18
+FROM apify/actor-node:20
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/templates/js-crawlee-cheerio/.actor/Dockerfile
+++ b/templates/js-crawlee-cheerio/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://docs.apify.com/sdk/js/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:18
+FROM apify/actor-node:20
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/templates/js-crawlee-playwright-chrome/.actor/Dockerfile
+++ b/templates/js-crawlee-playwright-chrome/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-playwright-chrome:18
+FROM apify/actor-node-playwright-chrome:20
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/templates/js-crawlee-puppeteer-chrome/.actor/Dockerfile
+++ b/templates/js-crawlee-puppeteer-chrome/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-puppeteer-chrome:18
+FROM apify/actor-node-puppeteer-chrome:20
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/templates/js-empty/.actor/Dockerfile
+++ b/templates/js-empty/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://docs.apify.com/sdk/js/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:18
+FROM apify/actor-node:20
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/templates/js-langchain/.actor/Dockerfile
+++ b/templates/js-langchain/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://docs.apify.com/sdk/js/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:18
+FROM apify/actor-node:20
 
 RUN apk add g++ make py3-pip
 

--- a/templates/js-start/.actor/Dockerfile
+++ b/templates/js-start/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://docs.apify.com/sdk/js/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:18
+FROM apify/actor-node:20
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/templates/ts-bootstrap-cheerio-crawler/.actor/Dockerfile
+++ b/templates/ts-bootstrap-cheerio-crawler/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:18 AS builder
+FROM apify/actor-node:20 AS builder
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.
@@ -19,7 +19,7 @@ COPY . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node:18
+FROM apify/actor-node:20
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/templates/ts-crawlee-cheerio/.actor/Dockerfile
+++ b/templates/ts-crawlee-cheerio/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:18 AS builder
+FROM apify/actor-node:20 AS builder
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.
@@ -19,7 +19,7 @@ COPY . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node:18
+FROM apify/actor-node:20
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/templates/ts-crawlee-playwright-chrome/.actor/Dockerfile
+++ b/templates/ts-crawlee-playwright-chrome/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-playwright-chrome:18 AS builder
+FROM apify/actor-node-playwright-chrome:20 AS builder
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.
@@ -19,7 +19,7 @@ COPY --chown=myuser . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node-playwright-chrome:18
+FROM apify/actor-node-playwright-chrome:20
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/templates/ts-crawlee-puppeteer-chrome/.actor/Dockerfile
+++ b/templates/ts-crawlee-puppeteer-chrome/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-puppeteer-chrome:18 AS builder
+FROM apify/actor-node-puppeteer-chrome:20 AS builder
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.
@@ -19,7 +19,7 @@ COPY --chown=myuser . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node-puppeteer-chrome:18
+FROM apify/actor-node-puppeteer-chrome:20
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/templates/ts-empty/.actor/Dockerfile
+++ b/templates/ts-empty/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://docs.apify.com/sdk/js/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:18 AS builder
+FROM apify/actor-node:20 AS builder
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.
@@ -19,7 +19,7 @@ COPY . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node:18
+FROM apify/actor-node:20
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/templates/ts-playwright-test-runner/.actor/Dockerfile
+++ b/templates/ts-playwright-test-runner/.actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node-playwright:18-1.37.1
+FROM apify/actor-node-playwright:20-1.37.1
 
 COPY package*.json ./
 

--- a/templates/ts-start/.actor/Dockerfile
+++ b/templates/ts-start/.actor/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://docs.apify.com/sdk/js/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:18 AS builder
+FROM apify/actor-node:20 AS builder
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.
@@ -19,7 +19,7 @@ COPY . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node:18
+FROM apify/actor-node:20
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.


### PR DESCRIPTION
Not sure if we have some good test suite to make sure the templates/SDK/Crawlee don't break down in Node 20. You know this random crap likes to happen :)