### PR TITLE
fix: python playwright template

### DIFF
--- a/templates/python-playwright/.actor/Dockerfile
+++ b/templates/python-playwright/.actor/Dockerfile
@@ -20,6 +20,10 @@ RUN echo "Python version:" \
  && echo "All installed Python packages:" \
  && pip freeze
 
+ # Install Playwright and its dependencies
+RUN playwright install-deps && \
+    playwright install
+
 # Next, copy the remaining files and directories with the source code.
 # Since we do this after installing the dependencies, quick build will be really fast
 # for most source file changes.


### PR DESCRIPTION
based on [Slack bug report](https://apify.slack.com/archives/C0L33UM7Z/p1718270319985559):

```text
There is a problem with the [Playwright + Chrome template](https://console.apify.com/actors/templates/python-playwright). When you use the template, build the Actor and try to run it, it returns this to the log:

playwright._impl._api_types.Error: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1084/chrome-linux/chrome
Looks like Playwright was just installed or updated.
Please run the following command to download new browsers:
playwright install

And then, when you add RUN playwright install to the Dockerfile, there is one more error, this time with playwright install-deps.

Only then, after you add RUN playwright install-deps to the Dockerfile, it finally works.
```
