### PR TITLE
fix: incorrect input_schema.json titles

### DIFF
--- a/templates/js-crawlee-puppeteer-chrome/.actor/input_schema.json
+++ b/templates/js-crawlee-puppeteer-chrome/.actor/input_schema.json
@@ -1,5 +1,5 @@
 {
-    "title": "PlaywrightCrawler Template",
+    "title": "PuppeteerCrawler Template",
     "type": "object",
     "schemaVersion": 1,
     "properties": {

--- a/templates/ts-crawlee-puppeteer-chrome/.actor/input_schema.json
+++ b/templates/ts-crawlee-puppeteer-chrome/.actor/input_schema.json
@@ -1,5 +1,5 @@
 {
-    "title": "PlaywrightCrawler Template",
+    "title": "PuppeteerCrawler Template",
     "type": "object",
     "schemaVersion": 1,
     "properties": {


### PR DESCRIPTION
Fix incorrect input_schema.json titles in crawlee-puppeteer-chrome templates