### PR TITLE
fix: Add 60 minutes timeout to template tests

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -54,6 +54,7 @@ jobs:
         node-version: [ 18, 20, 22 ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     steps:
     - name: Checkout repo
@@ -92,6 +93,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python-version: [ '3.9', '3.10', '3.11', '3.12' ]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     steps:
     - name: Checkout repo


### PR DESCRIPTION
The broken template tests cost us $500 in the last month, because the tests were running for 6 hours before they timed out. This adds a 1-hour time limit to them, so that next time they time out earlier and it's not so costly.

I checked and the tests typically run for 30 minutes, so 1 hour timeout should be enough.