### PR TITLE
fix: Add configs to ts templates

### DIFF
--- a/templates/ts-bootstrap-cheerio-crawler/.dockerignore
+++ b/templates/ts-bootstrap-cheerio-crawler/.dockerignore
@@ -1,5 +1,6 @@
 # configurations
 .idea
+.vscode
 
 # crawlee and apify storage folders
 storage

--- a/templates/ts-bootstrap-cheerio-crawler/.eslintrc
+++ b/templates/ts-bootstrap-cheerio-crawler/.eslintrc
@@ -1,4 +1,20 @@
 {
     "root": true,
-    "extends": "@apify/eslint-config-ts"
+    "env": {
+        "browser": true,
+        "es2020": true,
+        "node": true
+    },
+    "extends": [
+        "@apify/eslint-config-ts"
+    ],
+    "parserOptions": {
+        "project": "./tsconfig.json",
+        "ecmaVersion": 2020
+    },
+    "ignorePatterns": [
+        "node_modules",
+        "dist",
+        "**/*.d.ts"
+    ]
 }

--- a/templates/ts-bootstrap-cheerio-crawler/.gitignore
+++ b/templates/ts-bootstrap-cheerio-crawler/.gitignore
@@ -2,6 +2,7 @@
 
 .DS_Store
 .idea
+.vscode
 dist
 node_modules
 storage

--- a/templates/ts-bootstrap-cheerio-crawler/package.json
+++ b/templates/ts-bootstrap-cheerio-crawler/package.json
@@ -13,8 +13,8 @@
     "devDependencies": {
         "@apify/eslint-config-ts": "^0.3.0",
         "@apify/tsconfig": "^0.1.0",
-        "@typescript-eslint/eslint-plugin": "^6.7.2",
-        "@typescript-eslint/parser": "^6.7.2",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
         "eslint": "^8.50.0",
         "tsx": "^4.6.2",
         "typescript": "^5.3.3"

--- a/templates/ts-bootstrap-cheerio-crawler/tsconfig.json
+++ b/templates/ts-bootstrap-cheerio-crawler/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "extends": "@apify/tsconfig",
     "compilerOptions": {
-        "moduleResolution": "Node",
         "module": "NodeNext",
         "moduleResolution": "NodeNext",
         "target": "ES2022",

--- a/templates/ts-crawlee-cheerio/.dockerignore
+++ b/templates/ts-crawlee-cheerio/.dockerignore
@@ -1,5 +1,6 @@
 # configurations
 .idea
+.vscode
 
 # crawlee and apify storage folders
 apify_storage

--- a/templates/ts-crawlee-cheerio/.gitignore
+++ b/templates/ts-crawlee-cheerio/.gitignore
@@ -2,6 +2,7 @@
 
 .DS_Store
 .idea
+.vscode
 dist
 node_modules
 apify_storage

--- a/templates/ts-crawlee-cheerio/package.json
+++ b/templates/ts-crawlee-cheerio/package.json
@@ -13,8 +13,8 @@
     "devDependencies": {
         "@apify/eslint-config-ts": "^0.3.0",
         "@apify/tsconfig": "^0.1.0",
-        "@typescript-eslint/eslint-plugin": "^6.7.2",
-        "@typescript-eslint/parser": "^6.7.2",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
         "eslint": "^8.50.0",
         "tsx": "^4.6.2",
         "typescript": "^5.3.3"

--- a/templates/ts-crawlee-playwright-chrome/.dockerignore
+++ b/templates/ts-crawlee-playwright-chrome/.dockerignore
@@ -1,5 +1,6 @@
 # configurations
 .idea
+.vscode
 
 # crawlee and apify storage folders
 apify_storage

--- a/templates/ts-crawlee-playwright-chrome/.gitignore
+++ b/templates/ts-crawlee-playwright-chrome/.gitignore
@@ -2,6 +2,7 @@
 
 .DS_Store
 .idea
+.vscode
 dist
 node_modules
 apify_storage

--- a/templates/ts-crawlee-playwright-chrome/package.json
+++ b/templates/ts-crawlee-playwright-chrome/package.json
@@ -14,8 +14,8 @@
     "devDependencies": {
         "@apify/eslint-config-ts": "^0.3.0",
         "@apify/tsconfig": "^0.1.0",
-        "@typescript-eslint/eslint-plugin": "^6.7.2",
-        "@typescript-eslint/parser": "^6.7.2",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
         "eslint": "^8.50.0",
         "tsx": "^4.6.2",
         "typescript": "^5.3.3"

--- a/templates/ts-crawlee-puppeteer-chrome/.dockerignore
+++ b/templates/ts-crawlee-puppeteer-chrome/.dockerignore
@@ -1,5 +1,6 @@
 # configurations
 .idea
+.vscode
 
 # crawlee and apify storage folders
 apify_storage

--- a/templates/ts-crawlee-puppeteer-chrome/.gitignore
+++ b/templates/ts-crawlee-puppeteer-chrome/.gitignore
@@ -2,6 +2,7 @@
 
 .DS_Store
 .idea
+.vscode
 dist
 node_modules
 apify_storage

--- a/templates/ts-crawlee-puppeteer-chrome/package.json
+++ b/templates/ts-crawlee-puppeteer-chrome/package.json
@@ -14,8 +14,8 @@
     "devDependencies": {
         "@apify/eslint-config-ts": "^0.3.0",
         "@apify/tsconfig": "^0.1.0",
-        "@typescript-eslint/eslint-plugin": "^6.7.2",
-        "@typescript-eslint/parser": "^6.7.2",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
         "eslint": "^8.50.0",
         "tsx": "^4.6.2",
         "typescript": "^5.3.3"

--- a/templates/ts-empty/.dockerignore
+++ b/templates/ts-empty/.dockerignore
@@ -1,5 +1,6 @@
 # configurations
 .idea
+.vscode
 
 # crawlee and apify storage folders
 apify_storage

--- a/templates/ts-empty/.editorconfig
+++ b/templates/ts-empty/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf

--- a/templates/ts-empty/.eslintrc
+++ b/templates/ts-empty/.eslintrc
@@ -1,0 +1,20 @@
+{
+    "root": true,
+    "env": {
+        "browser": true,
+        "es2020": true,
+        "node": true
+    },
+    "extends": [
+        "@apify/eslint-config-ts"
+    ],
+    "parserOptions": {
+        "project": "./tsconfig.json",
+        "ecmaVersion": 2020
+    },
+    "ignorePatterns": [
+        "node_modules",
+        "dist",
+        "**/*.d.ts"
+    ]
+}

--- a/templates/ts-empty/.gitignore
+++ b/templates/ts-empty/.gitignore
@@ -1,3 +1,7 @@
+# This file tells Git which files shouldn't be added to source control
+
+.idea
+.vscode
 storage
 apify_storage
 crawlee_storage

--- a/templates/ts-empty/package.json
+++ b/templates/ts-empty/package.json
@@ -11,7 +11,11 @@
         "crawlee": "^3.5.4"
     },
     "devDependencies": {
+        "@apify/eslint-config-ts": "^0.3.0",
         "@apify/tsconfig": "^0.1.0",
+        "@typescript-eslint/eslint-plugin": "^6.7.2",
+        "@typescript-eslint/parser": "^6.7.2",
+        "eslint": "^8.50.0",
         "tsx": "^4.6.2",
         "typescript": "^5.3.3"
     },

--- a/templates/ts-empty/package.json
+++ b/templates/ts-empty/package.json
@@ -13,8 +13,8 @@
     "devDependencies": {
         "@apify/eslint-config-ts": "^0.3.0",
         "@apify/tsconfig": "^0.1.0",
-        "@typescript-eslint/eslint-plugin": "^6.7.2",
-        "@typescript-eslint/parser": "^6.7.2",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
         "eslint": "^8.50.0",
         "tsx": "^4.6.2",
         "typescript": "^5.3.3"

--- a/templates/ts-playwright-test-runner/.dockerignore
+++ b/templates/ts-playwright-test-runner/.dockerignore
@@ -1,5 +1,6 @@
 # configurations
 .idea
+.vscode
 
 # crawlee and apify storage folders
 apify_storage

--- a/templates/ts-playwright-test-runner/.editorconfig
+++ b/templates/ts-playwright-test-runner/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf

--- a/templates/ts-playwright-test-runner/.gitignore
+++ b/templates/ts-playwright-test-runner/.gitignore
@@ -1,3 +1,7 @@
+# This file tells Git which files shouldn't be added to source control
+
+.idea
+.vscode
 storage
 node_modules
 dist

--- a/templates/ts-standby/.dockerignore
+++ b/templates/ts-standby/.dockerignore
@@ -1,5 +1,6 @@
 # configurations
 .idea
+.vscode
 
 # crawlee and apify storage folders
 apify_storage

--- a/templates/ts-standby/.editorconfig
+++ b/templates/ts-standby/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf

--- a/templates/ts-standby/.eslintrc
+++ b/templates/ts-standby/.eslintrc
@@ -1,0 +1,20 @@
+{
+    "root": true,
+    "env": {
+        "browser": true,
+        "es2020": true,
+        "node": true
+    },
+    "extends": [
+        "@apify/eslint-config-ts"
+    ],
+    "parserOptions": {
+        "project": "./tsconfig.json",
+        "ecmaVersion": 2020
+    },
+    "ignorePatterns": [
+        "node_modules",
+        "dist",
+        "**/*.d.ts"
+    ]
+}

--- a/templates/ts-standby/.gitignore
+++ b/templates/ts-standby/.gitignore
@@ -1,3 +1,7 @@
+# This file tells Git which files shouldn't be added to source control
+
+.idea
+.vscode
 storage
 apify_storage
 crawlee_storage

--- a/templates/ts-standby/package.json
+++ b/templates/ts-standby/package.json
@@ -12,8 +12,8 @@
     "devDependencies": {
         "@apify/eslint-config-ts": "^0.3.0",
         "@apify/tsconfig": "^0.1.0",
-        "@typescript-eslint/eslint-plugin": "^6.7.2",
-        "@typescript-eslint/parser": "^6.7.2",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
         "eslint": "^8.50.0",
         "tsx": "^4.6.2",
         "typescript": "^5.3.3"

--- a/templates/ts-standby/package.json
+++ b/templates/ts-standby/package.json
@@ -10,7 +10,11 @@
         "apify": "^3.1.10"
     },
     "devDependencies": {
+        "@apify/eslint-config-ts": "^0.3.0",
         "@apify/tsconfig": "^0.1.0",
+        "@typescript-eslint/eslint-plugin": "^6.7.2",
+        "@typescript-eslint/parser": "^6.7.2",
+        "eslint": "^8.50.0",
         "tsx": "^4.6.2",
         "typescript": "^5.3.3"
     },

--- a/templates/ts-start-bun/.dockerignore
+++ b/templates/ts-start-bun/.dockerignore
@@ -1,5 +1,6 @@
 # configurations
 .idea
+.vscode
 
 # crawlee and apify storage folders
 apify_storage

--- a/templates/ts-start-bun/.editorconfig
+++ b/templates/ts-start-bun/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf

--- a/templates/ts-start-bun/.eslintrc
+++ b/templates/ts-start-bun/.eslintrc
@@ -1,0 +1,20 @@
+{
+    "root": true,
+    "env": {
+        "browser": true,
+        "es2020": true,
+        "node": true
+    },
+    "extends": [
+        "@apify/eslint-config-ts"
+    ],
+    "parserOptions": {
+        "project": "./tsconfig.json",
+        "ecmaVersion": 2020
+    },
+    "ignorePatterns": [
+        "node_modules",
+        "dist",
+        "**/*.d.ts"
+    ]
+}

--- a/templates/ts-start-bun/.gitignore
+++ b/templates/ts-start-bun/.gitignore
@@ -1,3 +1,7 @@
+# This file tells Git which files shouldn't be added to source control
+
+.idea
+.vscode
 storage
 apify_storage
 crawlee_storage

--- a/templates/ts-start-bun/package.json
+++ b/templates/ts-start-bun/package.json
@@ -12,7 +12,13 @@
         "cheerio": "^1.0.0-rc.12"
     },
     "devDependencies": {
-        "@apify/tsconfig": "^0.1.0"
+        "@apify/eslint-config-ts": "^0.3.0",
+        "@apify/tsconfig": "^0.1.0",
+        "@typescript-eslint/eslint-plugin": "^6.7.2",
+        "@typescript-eslint/parser": "^6.7.2",
+        "eslint": "^8.50.0",
+        "tsx": "^4.6.2",
+        "typescript": "^5.3.3"
     },
     "scripts": {
         "start": "bun src/main.ts",

--- a/templates/ts-start-bun/package.json
+++ b/templates/ts-start-bun/package.json
@@ -14,8 +14,8 @@
     "devDependencies": {
         "@apify/eslint-config-ts": "^0.3.0",
         "@apify/tsconfig": "^0.1.0",
-        "@typescript-eslint/eslint-plugin": "^6.7.2",
-        "@typescript-eslint/parser": "^6.7.2",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
         "eslint": "^8.50.0",
         "tsx": "^4.6.2",
         "typescript": "^5.3.3"

--- a/templates/ts-start-bun/src/main.ts
+++ b/templates/ts-start-bun/src/main.ts
@@ -31,7 +31,7 @@ const $ = cheerio.load(response.data);
 const headings: { level: string, text: string }[] = [];
 $("h1, h2, h3, h4, h5, h6").each((_i, element) => {
     const headingObject = {
-        level: $(element).prop("tagName").toLowerCase(),
+        level: $(element).prop("tagName")!.toLowerCase(),
         text: $(element).text(),
     };
     console.log("Extracted heading", headingObject);

--- a/templates/ts-start/.dockerignore
+++ b/templates/ts-start/.dockerignore
@@ -1,5 +1,6 @@
 # configurations
 .idea
+.vscode
 
 # crawlee and apify storage folders
 apify_storage

--- a/templates/ts-start/.editorconfig
+++ b/templates/ts-start/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf

--- a/templates/ts-start/.eslintrc
+++ b/templates/ts-start/.eslintrc
@@ -1,0 +1,20 @@
+{
+    "root": true,
+    "env": {
+        "browser": true,
+        "es2020": true,
+        "node": true
+    },
+    "extends": [
+        "@apify/eslint-config-ts"
+    ],
+    "parserOptions": {
+        "project": "./tsconfig.json",
+        "ecmaVersion": 2020
+    },
+    "ignorePatterns": [
+        "node_modules",
+        "dist",
+        "**/*.d.ts"
+    ]
+}

--- a/templates/ts-start/.gitignore
+++ b/templates/ts-start/.gitignore
@@ -1,3 +1,7 @@
+# This file tells Git which files shouldn't be added to source control
+
+.idea
+.vscode
 storage
 apify_storage
 crawlee_storage

--- a/templates/ts-start/package.json
+++ b/templates/ts-start/package.json
@@ -14,8 +14,8 @@
     "devDependencies": {
         "@apify/eslint-config-ts": "^0.3.0",
         "@apify/tsconfig": "^0.1.0",
-        "@typescript-eslint/eslint-plugin": "^6.7.2",
-        "@typescript-eslint/parser": "^6.7.2",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
         "eslint": "^8.50.0",
         "tsx": "^4.6.2",
         "typescript": "^5.3.3"

--- a/templates/ts-start/package.json
+++ b/templates/ts-start/package.json
@@ -12,7 +12,11 @@
         "cheerio": "^1.0.0-rc.12"
     },
     "devDependencies": {
+        "@apify/eslint-config-ts": "^0.3.0",
         "@apify/tsconfig": "^0.1.0",
+        "@typescript-eslint/eslint-plugin": "^6.7.2",
+        "@typescript-eslint/parser": "^6.7.2",
+        "eslint": "^8.50.0",
         "tsx": "^4.6.2",
         "typescript": "^5.3.3"
     },

--- a/templates/ts-start/src/main.ts
+++ b/templates/ts-start/src/main.ts
@@ -31,7 +31,7 @@ const $ = cheerio.load(response.data);
 const headings: { level: string, text: string }[] = [];
 $("h1, h2, h3, h4, h5, h6").each((_i, element) => {
     const headingObject = {
-        level: $(element).prop("tagName").toLowerCase(),
+        level: $(element).prop("tagName")!.toLowerCase(),
         text: $(element).text(),
     };
     console.log("Extracted heading", headingObject);


### PR DESCRIPTION
Recreation of this PR: https://github.com/apify/actor-templates/pull/294

- added ".vscode" to .gitignore and .dockerignore files
- added .editorconfig files to templates if missing
- added or updated .eslintrc
- updated package.json with eslint packages
- removed duplicate option in ts-bootstrap-cheerio-crawler/tsconfig.json
- non-null assertion fix in main.ts in ts-start and ts-start-bun templates
- change typescript-eslint version according to https://github.com/apify/actor-templates/pull/294#discussion_r1761010169

The issue of redundant config options (https://github.com/apify/actor-templates/pull/294#discussion_r1760838891) is not included.