### PR TITLE
chore: bump templates to latest crawlee & apify version

### DIFF
--- a/templates/js-bootstrap-cheerio-crawler/package.json
+++ b/templates/js-bootstrap-cheerio-crawler/package.json
@@ -7,8 +7,8 @@
         "node": ">=18.0.0"
     },
     "dependencies": {
-        "apify": "^3.1.10",
-        "crawlee": "^3.5.4"
+        "apify": "^3.2.6",
+        "crawlee": "^3.11.5"
     },
     "devDependencies": {
         "@apify/eslint-config": "^0.4.0",

--- a/templates/js-crawlee-cheerio/package.json
+++ b/templates/js-crawlee-cheerio/package.json
@@ -7,8 +7,8 @@
         "node": ">=18.0.0"
     },
     "dependencies": {
-        "apify": "^3.1.10",
-        "crawlee": "^3.5.4"
+        "apify": "^3.2.6",
+        "crawlee": "^3.11.5"
     },
     "devDependencies": {
         "@apify/eslint-config": "^0.4.0",

--- a/templates/js-crawlee-playwright-chrome/package.json
+++ b/templates/js-crawlee-playwright-chrome/package.json
@@ -4,8 +4,8 @@
     "type": "module",
     "description": "This is an example of an Apify actor.",
     "dependencies": {
-        "apify": "^3.1.10",
-        "crawlee": "^3.5.4",
+        "apify": "^3.2.6",
+        "crawlee": "^3.11.5",
         "playwright": "*"
     },
     "devDependencies": {

--- a/templates/js-crawlee-puppeteer-chrome/package.json
+++ b/templates/js-crawlee-puppeteer-chrome/package.json
@@ -4,8 +4,8 @@
     "type": "module",
     "description": "This is an example of an Apify actor.",
     "dependencies": {
-        "apify": "^3.1.10",
-        "crawlee": "^3.5.4",
+        "apify": "^3.2.6",
+        "crawlee": "^3.11.5",
         "puppeteer": "*"
     },
     "devDependencies": {

--- a/templates/js-cypress/package.json
+++ b/templates/js-cypress/package.json
@@ -8,7 +8,7 @@
     },
     "dependencies": {
         "@apify/log": "^2.2.7",
-        "apify": "^3.1.10",
+        "apify": "^3.2.6",
         "console.table": "^0.10.0",
         "cypress": "^12.7.0",
         "globby": "^13.1.3"

--- a/templates/js-empty/package.json
+++ b/templates/js-empty/package.json
@@ -7,8 +7,8 @@
         "node": ">=18.0.0"
     },
     "dependencies": {
-        "apify": "^3.1.10",
-        "crawlee": "^3.5.4"
+        "apify": "^3.2.6",
+        "crawlee": "^3.11.5"
     },
     "scripts": {
         "start": "node ./src/main.js",

--- a/templates/js-langchain/package.json
+++ b/templates/js-langchain/package.json
@@ -10,7 +10,7 @@
         "@langchain/community": "^0.2.32",
         "@langchain/core": "^0.2.31",
         "@langchain/openai": "^0.2.10",
-        "apify": "^3.1.10",
+        "apify": "^3.2.6",
         "hnswlib-node": "^3.0.0",
         "langchain": "^0.2.18",
         "tar": "^6.1.14"

--- a/templates/js-standby/package.json
+++ b/templates/js-standby/package.json
@@ -7,7 +7,7 @@
         "node": ">=20.0.0"
     },
     "dependencies": {
-        "apify": "^3.1.10"
+        "apify": "^3.2.6"
     },
     "scripts": {
         "start": "node ./src/main.js",

--- a/templates/js-start/package.json
+++ b/templates/js-start/package.json
@@ -7,7 +7,7 @@
         "node": ">=18.0.0"
     },
     "dependencies": {
-        "apify": "^3.1.10",
+        "apify": "^3.2.6",
         "axios": "^1.5.0",
         "cheerio": "^1.0.0-rc.12"
     },

--- a/templates/ts-bootstrap-cheerio-crawler/package.json
+++ b/templates/ts-bootstrap-cheerio-crawler/package.json
@@ -7,8 +7,8 @@
         "node": ">=18.0.0"
     },
     "dependencies": {
-        "apify": "^3.1.10",
-        "crawlee": "^3.5.4"
+        "apify": "^3.2.6",
+        "crawlee": "^3.11.5"
     },
     "devDependencies": {
         "@apify/eslint-config-ts": "^0.3.0",

--- a/templates/ts-crawlee-cheerio/package.json
+++ b/templates/ts-crawlee-cheerio/package.json
@@ -7,8 +7,8 @@
         "node": ">=18.0.0"
     },
     "dependencies": {
-        "apify": "^3.1.10",
-        "crawlee": "^3.5.4"
+        "apify": "^3.2.6",
+        "crawlee": "^3.11.5"
     },
     "devDependencies": {
         "@apify/eslint-config-ts": "^0.3.0",

--- a/templates/ts-crawlee-playwright-chrome/package.json
+++ b/templates/ts-crawlee-playwright-chrome/package.json
@@ -7,8 +7,8 @@
         "node": ">=18.0.0"
     },
     "dependencies": {
-        "apify": "^3.1.10",
-        "crawlee": "^3.5.4",
+        "apify": "^3.2.6",
+        "crawlee": "^3.11.5",
         "playwright": "*"
     },
     "devDependencies": {

--- a/templates/ts-crawlee-puppeteer-chrome/package.json
+++ b/templates/ts-crawlee-puppeteer-chrome/package.json
@@ -7,8 +7,8 @@
         "node": ">=18.0.0"
     },
     "dependencies": {
-        "apify": "^3.1.10",
-        "crawlee": "^3.5.4",
+        "apify": "^3.2.6",
+        "crawlee": "^3.11.5",
         "puppeteer": "*"
     },
     "devDependencies": {

--- a/templates/ts-empty/package.json
+++ b/templates/ts-empty/package.json
@@ -7,8 +7,8 @@
         "node": ">=18.0.0"
     },
     "dependencies": {
-        "apify": "^3.1.10",
-        "crawlee": "^3.5.4"
+        "apify": "^3.2.6",
+        "crawlee": "^3.11.5"
     },
     "devDependencies": {
         "@apify/eslint-config-ts": "^0.3.0",

--- a/templates/ts-playwright-test-runner/package.json
+++ b/templates/ts-playwright-test-runner/package.json
@@ -20,7 +20,7 @@
         "@apify/tsconfig": "^0.1.0",
         "@playwright/test": "1.37.1",
         "@types/uuid": "^9.0.4",
-        "apify": "^3.1.10",
+        "apify": "^3.2.6",
         "tsx": "^4.6.2",
         "typescript": "^5.3.3",
         "uuid": "^9.0.1"

--- a/templates/ts-standby/package.json
+++ b/templates/ts-standby/package.json
@@ -7,7 +7,7 @@
         "node": ">=20.0.0"
     },
     "dependencies": {
-        "apify": "^3.1.10"
+        "apify": "^3.2.6"
     },
     "devDependencies": {
         "@apify/eslint-config-ts": "^0.3.0",

--- a/templates/ts-start-bun/package.json
+++ b/templates/ts-start-bun/package.json
@@ -7,7 +7,7 @@
         "bun": ">=1.0.0"
     },
     "dependencies": {
-        "apify": "^3.1.10",
+        "apify": "^3.2.6",
         "axios": "^1.5.0",
         "cheerio": "^1.0.0-rc.12"
     },

--- a/templates/ts-start/package.json
+++ b/templates/ts-start/package.json
@@ -7,7 +7,7 @@
         "node": ">=18.0.0"
     },
     "dependencies": {
-        "apify": "^3.1.10",
+        "apify": "^3.2.6",
         "axios": "^1.5.0",
         "cheerio": "^1.0.0-rc.12"
     },


### PR DESCRIPTION
This is done manually like this once a while?