### PR TITLE
feat: Update js-langchain template to pin langchainjs to the latest version

### DIFF
--- a/templates/js-langchain/package.json
+++ b/templates/js-langchain/package.json
@@ -1,18 +1,18 @@
 {
     "name": "project-langchain",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "type": "module",
     "description": "This is a boilerplate of an Apify actor.",
     "engines": {
         "node": ">=18.0.0"
     },
     "dependencies": {
-        "@langchain/community": "^0.2.32",
-        "@langchain/core": "^0.2.31",
-        "@langchain/openai": "^0.2.10",
+        "@langchain/community": "^0.3.9",
+        "@langchain/core": "^0.3.15",
+        "@langchain/openai": "^0.3.11",
         "apify": "^3.2.6",
         "hnswlib-node": "^3.0.0",
-        "langchain": "^0.2.18",
+        "langchain": "^0.3.4",
         "tar": "^6.1.14"
     },
     "scripts": {


### PR DESCRIPTION
In the latest version of langchainjs we've modified the user agent (addded `Origin/langchainjs`) for the apify-client to attribute API activity to langchainjs