### PR TITLE
chore: bump `ts-playwright-test-runner` Playwright and Node version

### DIFF
--- a/templates/js-crawlee-playwright-chrome/src/main.js
+++ b/templates/js-crawlee-playwright-chrome/src/main.js
@@ -24,6 +24,13 @@ const proxyConfiguration = await Actor.createProxyConfiguration();
 const crawler = new PlaywrightCrawler({
     proxyConfiguration,
     requestHandler: router,
+    launchContext: {
+        launchOptions: {
+            args: [
+                '--disable-gpu', // Mitigates the "crashing GPU process" issue in Docker containers
+            ]
+        }
+    }
 });
 
 await crawler.run(startUrls);

--- a/templates/js-crawlee-puppeteer-chrome/src/main.js
+++ b/templates/js-crawlee-puppeteer-chrome/src/main.js
@@ -20,6 +20,13 @@ const proxyConfiguration = await Actor.createProxyConfiguration();
 const crawler = new PuppeteerCrawler({
     proxyConfiguration,
     requestHandler: router,
+    launchContext: {
+        launchOptions: {
+            args: [
+                '--disable-gpu', // Mitigates the "crashing GPU process" issue in Docker containers
+            ]
+        }
+    }
 });
 
 // Run the crawler with the start URLs and wait for it to finish.

--- a/templates/python-crawlee-playwright/src/main.py
+++ b/templates/python-crawlee-playwright/src/main.py
@@ -32,6 +32,9 @@ async def main() -> None:
             # Limit the crawl to max requests. Remove or increase it for crawling all links.
             max_requests_per_crawl=50,
             headless=True,
+            browser_options={
+                'args': ['--disable-gpu'],
+            }
         )
 
         # Define a request handler, which will be called for every request.

--- a/templates/python-playwright/src/main.py
+++ b/templates/python-playwright/src/main.py
@@ -50,7 +50,7 @@ async def main() -> None:
         # Launch Playwright and open a new browser context.
         async with async_playwright() as playwright:
             # Configure the browser to launch in headless mode as per Actor configuration.
-            browser = await playwright.chromium.launch(headless=Actor.config.headless)
+            browser = await playwright.chromium.launch(headless=Actor.config.headless, args=['--disable-gpu'])
             context = await browser.new_context()
 
             # Process the URLs from the request queue.

--- a/templates/ts-crawlee-playwright-chrome/src/main.ts
+++ b/templates/ts-crawlee-playwright-chrome/src/main.ts
@@ -33,6 +33,13 @@ const crawler = new PlaywrightCrawler({
     proxyConfiguration,
     maxRequestsPerCrawl,
     requestHandler: router,
+    launchContext: {
+        launchOptions: {
+            args: [
+                '--disable-gpu', // Mitigates the "crashing GPU process" issue in Docker containers
+            ]
+        }
+    }
 });
 
 await crawler.run(startUrls);

--- a/templates/ts-crawlee-puppeteer-chrome/src/main.ts
+++ b/templates/ts-crawlee-puppeteer-chrome/src/main.ts
@@ -22,6 +22,13 @@ const proxyConfiguration = await Actor.createProxyConfiguration();
 const crawler = new PuppeteerCrawler({
     proxyConfiguration,
     requestHandler: router,
+    launchContext: {
+        launchOptions: {
+            args: [
+                '--disable-gpu', // Mitigates the "crashing GPU process" issue in Docker containers
+            ]
+        }
+    }
 });
 
 // Run the crawler with the start URLs and wait for it to finish.

--- a/templates/ts-playwright-test-runner/.actor/Dockerfile
+++ b/templates/ts-playwright-test-runner/.actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node-playwright:20-1.37.1
+FROM apify/actor-node-playwright:22-1.49.1
 
 COPY package*.json ./
 

--- a/templates/ts-playwright-test-runner/.dockerignore
+++ b/templates/ts-playwright-test-runner/.dockerignore
@@ -10,6 +10,7 @@ storage
 # generated test results
 playwright-report
 test-results.json
+test-results
 
 # installed files
 node_modules

--- a/templates/ts-playwright-test-runner/.gitignore
+++ b/templates/ts-playwright-test-runner/.gitignore
@@ -8,3 +8,4 @@ dist
 playwright-report
 src/tests
 test-results.json
+test-results/

--- a/templates/ts-playwright-test-runner/package.json
+++ b/templates/ts-playwright-test-runner/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "@apify/eslint-config-ts": "^0.3.0",
         "@apify/tsconfig": "^0.1.0",
-        "@playwright/test": "1.37.1",
+        "@playwright/test": "1.49.1",
         "@types/uuid": "^9.0.4",
         "apify": "^3.2.6",
         "tsx": "^4.6.2",

--- a/templates/ts-playwright-test-runner/src/main.ts
+++ b/templates/ts-playwright-test-runner/src/main.ts
@@ -40,7 +40,7 @@ export default defineConfig({
         video: '${video}',
         launchOptions: {
             args: [
-                '--disable-gpu',
+                '--disable-gpu', // Mitigates the "crashing GPU process" issue in Docker containers
             ]
         },
     },

--- a/templates/ts-playwright-test-runner/src/main.ts
+++ b/templates/ts-playwright-test-runner/src/main.ts
@@ -38,6 +38,11 @@ export default defineConfig({
         colorScheme: '${darkMode ? 'dark' : 'light'}',
         locale: '${locale}',
         video: '${video}',
+        launchOptions: {
+            args: [
+                '--disable-gpu',
+            ]
+        },
     },
     reporter: [
         ['html', { outputFolder: '${getResultDir()}', open: 'never' }],

--- a/templates/ts-playwright-test-runner/tests/first.spec.ts
+++ b/templates/ts-playwright-test-runner/tests/first.spec.ts
@@ -3,8 +3,12 @@ import { test, expect } from '@playwright/test';
 test('has appropriate size', async ({ page }) => {
     let totalDownloaded = 0;
 
-    await page.on('response', async (r) => {
-        totalDownloaded += await (await r.body()).byteLength;
+    await page.on('response', (r) => {
+        r.body().then((b) => {
+            totalDownloaded += b.byteLength;
+        }).catch(() => {
+            // Ignore errors.
+        });
     });
 
     await page.goto('https://apify.com/about', { waitUntil: 'networkidle' });


### PR DESCRIPTION
Bumps the Playwright and Node versions in the template to `latest`s. Fixes the hanging `browserContext.newPage()` call by passing the `--disable-gpu` launch option to the browser.

More context at https://apify.slack.com/archives/CGZSN9DQC/p1733928283797729