### PR TITLE
feat: add Camoufox-based Crawlee JS/TS templates

### DIFF
--- a/templates/js-crawlee-playwright-camoufox/.actor/Dockerfile
+++ b/templates/js-crawlee-playwright-camoufox/.actor/Dockerfile
@@ -1,0 +1,33 @@
+# Specify the base Docker image. You can read more about
+# the available images at https://crawlee.dev/docs/guides/docker-images
+# You can also use any other image from Docker Hub.
+FROM apify/actor-node-playwright-chrome:20
+
+# Check preinstalled packages
+RUN npm ls crawlee apify playwright
+
+# Copy just package.json and package-lock.json
+# to speed up the build using Docker layer cache.
+COPY --chown=myuser package*.json ./
+
+# Install NPM packages, skip optional and development dependencies to
+# keep the image small. Avoid logging too much and print the dependency
+# tree for debugging
+RUN npm --quiet set progress=false \
+    && npm install --omit=dev \
+    && echo "Installed NPM packages:" \
+    && (npm list --omit=dev --all || true) \
+    && echo "Node.js version:" \
+    && node --version \
+    && echo "NPM version:" \
+    && npm --version \
+    && rm -r ~/.npm
+
+# Next, copy the remaining files and directories with the source code.
+# Since we do this after NPM install, quick build will be really fast
+# for most source file changes.
+COPY --chown=myuser . ./
+
+# Run the image. If you know you won't need headful browsers,
+# you can remove the XVFB start script for a micro perf gain.
+CMD ./start_xvfb_and_run_cmd.sh && npm start --silent

--- a/templates/js-crawlee-playwright-camoufox/.actor/actor.json
+++ b/templates/js-crawlee-playwright-camoufox/.actor/actor.json
@@ -1,0 +1,12 @@
+{
+    "actorSpecification": 1,
+    "name": "project-playwright-camoufox-crawler-javascript",
+    "title": "Camoufox Playwright Crawler JavaScript",
+    "description": "Crawlee and Playwright project with Camoufox in JavaScript.",
+    "version": "0.0",
+    "meta": {
+        "templateId": "js-crawlee-playwright-camoufox"
+    },
+    "input": "./input_schema.json",
+    "dockerfile": "./Dockerfile"
+}

--- a/templates/js-crawlee-playwright-camoufox/.actor/input_schema.json
+++ b/templates/js-crawlee-playwright-camoufox/.actor/input_schema.json
@@ -1,0 +1,18 @@
+{
+    "title": "PlaywrightCrawler Template",
+    "type": "object",
+    "schemaVersion": 1,
+    "properties": {
+        "startUrls": {
+            "title": "Start URLs",
+            "type": "array",
+            "description": "URLs to start with.",
+            "editor": "requestListSources",
+            "prefill": [
+                {
+                    "url": "https://apify.com"
+                }
+            ]
+        }
+    }
+}

--- a/templates/js-crawlee-playwright-camoufox/.dockerignore
+++ b/templates/js-crawlee-playwright-camoufox/.dockerignore
@@ -1,0 +1,13 @@
+# configurations
+.idea
+
+# crawlee and apify storage folders
+apify_storage
+crawlee_storage
+storage
+
+# installed files
+node_modules
+
+# git folder
+.git

--- a/templates/js-crawlee-playwright-camoufox/.editorconfig
+++ b/templates/js-crawlee-playwright-camoufox/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf

--- a/templates/js-crawlee-playwright-camoufox/.eslintrc
+++ b/templates/js-crawlee-playwright-camoufox/.eslintrc
@@ -1,0 +1,4 @@
+{
+    "extends": "@apify",
+    "root": true
+}

--- a/templates/js-crawlee-playwright-camoufox/.gitignore
+++ b/templates/js-crawlee-playwright-camoufox/.gitignore
@@ -1,0 +1,8 @@
+# This file tells Git which files shouldn't be added to source control
+
+.DS_Store
+.idea
+dist
+node_modules
+apify_storage
+storage

--- a/templates/js-crawlee-playwright-camoufox/README.md
+++ b/templates/js-crawlee-playwright-camoufox/README.md
@@ -1,0 +1,21 @@
+## PlaywrightCrawler template
+
+This template is a production-ready boilerplate for developing an [Actor](https://apify.com/actors) with `PlaywrightCrawler`. Use this to bootstrap your projects using the most up-to-date code.
+
+> We decided to split Apify SDK into two libraries, Crawlee and Apify SDK v3. Crawlee will retain all the crawling and scraping-related tools and will always strive to be the best [web scraping](https://apify.com/web-scraping) library for its community. At the same time, Apify SDK will continue to exist, but keep only the Apify-specific features related to building actors on the Apify platform. Read the upgrading guide to learn about the changes.
+> 
+
+## Resources
+
+If you're looking for examples or want to learn more visit:
+
+- [Crawlee + Apify Platform guide](https://crawlee.dev/docs/guides/apify-platform)
+- [Documentation](https://crawlee.dev/api/playwright-crawler/class/PlaywrightCrawler) and [examples](https://crawlee.dev/docs/examples/playwright-crawler)
+- [Node.js tutorials](https://docs.apify.com/academy/node-js) in Academy
+- [Scraping single-page applications with Playwright](https://blog.apify.com/scraping-single-page-applications-with-playwright/)
+- [How to scale Puppeteer and Playwright](https://blog.apify.com/how-to-scale-puppeteer-and-playwright/)
+- [Integration with Zapier](https://apify.com/integrations), Make, GitHub, Google Drive and other apps
+- [Video guide on getting data using Apify API](https://www.youtube.com/watch?v=ViYYDHSBAKM)
+- A short guide on how to create Actors using code templates:
+
+[web scraper template](https://www.youtube.com/watch?v=u-i-Korzf8w)

--- a/templates/js-crawlee-playwright-camoufox/README.md
+++ b/templates/js-crawlee-playwright-camoufox/README.md
@@ -1,9 +1,11 @@
-## PlaywrightCrawler template
+## PlaywrightCrawler + Camoufox template
 
-This template is a production-ready boilerplate for developing an [Actor](https://apify.com/actors) with `PlaywrightCrawler`. Use this to bootstrap your projects using the most up-to-date code.
+This template is a production-ready boilerplate for developing an [Actor](https://apify.com/actors) with `PlaywrightCrawler`. It has [Camoufox](https://github.com/daijro/camoufox) - a stealthy fork of Firefox - preinstalled. Note that Camoufox might consume more resources than the default Playwright-bundled Chromium or Firefox.
+
+Use this template to bootstrap your projects using the most up-to-date code.
 
 > We decided to split Apify SDK into two libraries, Crawlee and Apify SDK v3. Crawlee will retain all the crawling and scraping-related tools and will always strive to be the best [web scraping](https://apify.com/web-scraping) library for its community. At the same time, Apify SDK will continue to exist, but keep only the Apify-specific features related to building actors on the Apify platform. Read the upgrading guide to learn about the changes.
-> 
+>
 
 ## Resources
 

--- a/templates/js-crawlee-playwright-camoufox/package.json
+++ b/templates/js-crawlee-playwright-camoufox/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "crawlee-playwright-javascript-camoufox",
+    "version": "0.0.1",
+    "type": "module",
+    "description": "This is an example of an Apify actor.",
+    "dependencies": {
+        "apify": "^3.2.6",
+        "camoufox-js": "^0.1.3",
+        "crawlee": "^3.11.5",
+        "playwright": "*"
+    },
+    "devDependencies": {
+        "@apify/eslint-config": "^0.4.0",
+        "eslint": "^8.50.0"
+    },
+    "scripts": {
+        "start": "node src/main.js",
+        "lint": "eslint ./src --ext .js,.jsx",
+        "lint:fix": "eslint ./src --ext .js,.jsx --fix",
+        "test": "echo \"Error: oops, the actor has no tests yet, sad!\" && exit 1",
+        "postinstall": "npx camoufox-js fetch"
+    },
+    "author": "It's not you it's me",
+    "license": "ISC"
+}

--- a/templates/js-crawlee-playwright-camoufox/package.json
+++ b/templates/js-crawlee-playwright-camoufox/package.json
@@ -3,6 +3,9 @@
     "version": "0.0.1",
     "type": "module",
     "description": "This is an example of an Apify actor.",
+    "engines": {
+        "node": ">=20.0.0"
+    },
     "dependencies": {
         "apify": "^3.2.6",
         "camoufox-js": "^0.1.3",

--- a/templates/js-crawlee-playwright-camoufox/src/main.js
+++ b/templates/js-crawlee-playwright-camoufox/src/main.js
@@ -1,0 +1,41 @@
+/**
+ * This template is a production ready boilerplate for developing with `PlaywrightCrawler`.
+ * Use this to bootstrap your projects using the most up-to-date code.
+ * If you're looking for examples or want to learn more, see README.
+ */
+
+// For more information, see https://docs.apify.com/sdk/js
+import { Actor } from 'apify';
+// For more information, see https://crawlee.dev
+import { PlaywrightCrawler } from 'crawlee';
+// this is ESM project, and as such, it requires you to specify extensions in your relative imports
+// read more about this here: https://nodejs.org/docs/latest-v18.x/api/esm.html#mandatory-file-extensions
+import { router } from './routes.js';
+import { firefox } from 'playwright';
+import { launchOptions as camoufoxLaunchOptions } from 'camoufox-js';
+
+// Initialize the Apify SDK
+await Actor.init();
+
+const {
+    startUrls = ['https://crawlee.dev'],
+} = await Actor.getInput() ?? {};
+
+const proxyConfiguration = await Actor.createProxyConfiguration();
+
+const crawler = new PlaywrightCrawler({
+    proxyConfiguration,
+    requestHandler: router,
+    launchContext: {
+        launcher: firefox,
+        launchOptions: await camoufoxLaunchOptions({
+            // fonts: ['Times New Roman'], // <- custom Camoufox options
+            args: ['--disable-gpu'], // Mitigates the "crashing GPU process" issue in Docker containers
+        }),
+    }
+});
+
+await crawler.run(startUrls);
+
+// Exit successfully
+await Actor.exit();

--- a/templates/js-crawlee-playwright-camoufox/src/main.js
+++ b/templates/js-crawlee-playwright-camoufox/src/main.js
@@ -29,6 +29,7 @@ const crawler = new PlaywrightCrawler({
     launchContext: {
         launcher: firefox,
         launchOptions: await camoufoxLaunchOptions({
+            headless: true,
             // fonts: ['Times New Roman'], // <- custom Camoufox options
             args: ['--disable-gpu'], // Mitigates the "crashing GPU process" issue in Docker containers
         }),

--- a/templates/js-crawlee-playwright-camoufox/src/main.js
+++ b/templates/js-crawlee-playwright-camoufox/src/main.js
@@ -31,7 +31,6 @@ const crawler = new PlaywrightCrawler({
         launchOptions: await camoufoxLaunchOptions({
             headless: true,
             // fonts: ['Times New Roman'], // <- custom Camoufox options
-            args: ['--disable-gpu'], // Mitigates the "crashing GPU process" issue in Docker containers
         }),
     }
 });

--- a/templates/js-crawlee-playwright-camoufox/src/routes.js
+++ b/templates/js-crawlee-playwright-camoufox/src/routes.js
@@ -1,0 +1,21 @@
+import { Dataset, createPlaywrightRouter } from 'crawlee';
+
+export const router = createPlaywrightRouter();
+
+router.addDefaultHandler(async ({ enqueueLinks, log }) => {
+    log.info(`enqueueing new URLs`);
+    await enqueueLinks({
+        globs: ['https://apify.com/*'],
+        label: 'detail',
+    });
+});
+
+router.addHandler('detail', async ({ request, page, log }) => {
+    const title = await page.title();
+    log.info(`${title}`, { url: request.loadedUrl });
+
+    await Dataset.pushData({
+        url: request.loadedUrl,
+        title,
+    });
+});

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -430,6 +430,32 @@
             ]
         },
         {
+            "id": "js-crawlee-playwright-camoufox",
+            "name": "project_playwright_crawler_js",
+            "label": "Crawlee + Playwright + Camoufox",
+            "category": "javascript",
+            "technologies": [
+                "nodejs",
+                "crawlee",
+                "playwright",
+                "camoufox"
+            ],
+            "description": "Web scraper example with Crawlee, Playwright and Camoufox. Camoufox is a custom stealthy fork of Firefox. Try this template if you're facing anti-scraping challenges.",
+            "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/js-crawlee-playwright-camoufox.zip?raw=true",
+            "defaultRunOptions": {
+                "build": "latest",
+                "memoryMbytes": 4096,
+                "timeoutSecs": 3600
+            },
+            "showcaseFiles": [
+                "src/main.js",
+                "src/routes.js"
+            ],
+            "useCases": [
+                "WEB_SCRAPING"
+            ]
+        },
+        {
             "id": "js-bootstrap-cheerio-crawler",
             "name": "js-bootstrap-cheerio-crawler",
             "label": "Bootstrap CheerioCrawler",
@@ -519,6 +545,32 @@
             ],
             "description": "Web scraper example with Crawlee, Playwright and headless Chrome. Playwright is more modern, user-friendly and harder to block than Puppeteer.",
             "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/ts-crawlee-playwright-chrome.zip?raw=true",
+            "defaultRunOptions": {
+                "build": "latest",
+                "memoryMbytes": 4096,
+                "timeoutSecs": 3600
+            },
+            "showcaseFiles": [
+                "src/main.ts",
+                "src/routes.ts"
+            ],
+            "useCases": [
+                "WEB_SCRAPING"
+            ]
+        },
+        {
+            "id": "ts-crawlee-playwright-camoufox",
+            "name": "project_playwright_crawler_ts",
+            "label": "Crawlee + Playwright + Camoufox",
+            "category": "typescript",
+            "technologies": [
+                "nodejs",
+                "crawlee",
+                "playwright",
+                "camoufox"
+            ],
+            "description": "Web scraper example with Crawlee, Playwright and headless Camoufox. Camoufox is a custom stealthy fork of Firefox. Try this template if you're facing anti-scraping challenges.",
+            "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/ts-crawlee-playwright-camoufox.zip?raw=true",
             "defaultRunOptions": {
                 "build": "latest",
                 "memoryMbytes": 4096,

--- a/templates/ts-crawlee-playwright-camoufox/.actor/Dockerfile
+++ b/templates/ts-crawlee-playwright-camoufox/.actor/Dockerfile
@@ -1,0 +1,60 @@
+# Specify the base Docker image. You can read more about
+# the available images at https://crawlee.dev/docs/guides/docker-images
+# You can also use any other image from Docker Hub.
+FROM apify/actor-node-playwright-chrome:20 AS builder
+
+# Check preinstalled packages
+RUN npm ls crawlee apify puppeteer playwright
+
+# Copy just package.json and package-lock.json
+# to speed up the build using Docker layer cache.
+COPY --chown=myuser package*.json ./
+
+# Install all dependencies. Don't audit to speed up the installation.
+RUN npm install --include=dev --audit=false
+
+# Next, copy the source files using the user set
+# in the base image.
+COPY --chown=myuser . ./
+
+# Install all dependencies and build the project.
+# Don't audit to speed up the installation.
+RUN npm run build
+
+# Create final image
+FROM apify/actor-node-playwright-chrome:20
+
+# Check preinstalled packages
+RUN npm ls crawlee apify puppeteer playwright
+
+# Copy just package.json and package-lock.json
+# to speed up the build using Docker layer cache.
+COPY --chown=myuser package*.json ./
+
+# Install NPM packages, skip optional and development dependencies to
+# keep the image small. Avoid logging too much and print the dependency
+# tree for debugging
+RUN npm --quiet set progress=false \
+    && npm install --omit=dev \
+    && echo "Installed NPM packages:" \
+    && (npm list --omit=dev --all || true) \
+    && echo "Node.js version:" \
+    && node --version \
+    && echo "NPM version:" \
+    && npm --version \
+    && rm -r ~/.npm
+
+RUN npx camoufox-js fetch
+
+# Copy built JS files from builder image
+COPY --from=builder --chown=myuser /home/myuser/dist ./dist
+
+# Next, copy the remaining files and directories with the source code.
+# Since we do this after NPM install, quick build will be really fast
+# for most source file changes.
+COPY --chown=myuser . ./
+
+
+# Run the image. If you know you won't need headful browsers,
+# you can remove the XVFB start script for a micro perf gain.
+CMD ./start_xvfb_and_run_cmd.sh && npm run start:prod --silent

--- a/templates/ts-crawlee-playwright-camoufox/.actor/actor.json
+++ b/templates/ts-crawlee-playwright-camoufox/.actor/actor.json
@@ -1,0 +1,12 @@
+{
+    "actorSpecification": 1,
+    "name": "project-playwright-camoufox-crawler-typescript",
+    "title": "Camoufox Playwright Crawler TypeScript",
+    "description": "Crawlee and Playwright project with Camoufox in TypeScript.",
+    "version": "0.0",
+    "meta": {
+        "templateId": "ts-crawlee-playwright-chrome"
+    },
+    "input": "./input_schema.json",
+    "dockerfile": "./Dockerfile"
+}

--- a/templates/ts-crawlee-playwright-camoufox/.actor/actor.json
+++ b/templates/ts-crawlee-playwright-camoufox/.actor/actor.json
@@ -5,7 +5,7 @@
     "description": "Crawlee and Playwright project with Camoufox in TypeScript.",
     "version": "0.0",
     "meta": {
-        "templateId": "ts-crawlee-playwright-chrome"
+        "templateId": "ts-crawlee-playwright-camoufox"
     },
     "input": "./input_schema.json",
     "dockerfile": "./Dockerfile"

--- a/templates/ts-crawlee-playwright-camoufox/.actor/input_schema.json
+++ b/templates/ts-crawlee-playwright-camoufox/.actor/input_schema.json
@@ -1,0 +1,24 @@
+{
+    "title": "PlaywrightCrawler Template",
+    "type": "object",
+    "schemaVersion": 1,
+    "properties": {
+        "startUrls": {
+            "title": "Start URLs",
+            "type": "array",
+            "description": "URLs to start with.",
+            "editor": "requestListSources",
+            "prefill": [
+                {
+                    "url": "https://crawlee.dev"
+                }
+            ]
+        },
+        "maxRequestsPerCrawl": {
+            "title": "Max Requests per Crawl",
+            "type": "integer",
+            "description": "Maximum number of requests that can be made by this crawler.",
+            "default": 100
+        }
+    }
+}

--- a/templates/ts-crawlee-playwright-camoufox/.dockerignore
+++ b/templates/ts-crawlee-playwright-camoufox/.dockerignore
@@ -1,0 +1,14 @@
+# configurations
+.idea
+.vscode
+
+# crawlee and apify storage folders
+apify_storage
+crawlee_storage
+storage
+
+# installed files
+node_modules
+
+# git folder
+.git

--- a/templates/ts-crawlee-playwright-camoufox/.editorconfig
+++ b/templates/ts-crawlee-playwright-camoufox/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf

--- a/templates/ts-crawlee-playwright-camoufox/.eslintrc
+++ b/templates/ts-crawlee-playwright-camoufox/.eslintrc
@@ -1,0 +1,20 @@
+{
+    "root": true,
+    "env": {
+        "browser": true,
+        "es2020": true,
+        "node": true
+    },
+    "extends": [
+        "@apify/eslint-config-ts"
+    ],
+    "parserOptions": {
+        "project": "./tsconfig.json",
+        "ecmaVersion": 2020
+    },
+    "ignorePatterns": [
+        "node_modules",
+        "dist",
+        "**/*.d.ts"
+    ]
+}

--- a/templates/ts-crawlee-playwright-camoufox/.gitignore
+++ b/templates/ts-crawlee-playwright-camoufox/.gitignore
@@ -1,0 +1,9 @@
+# This file tells Git which files shouldn't be added to source control
+
+.DS_Store
+.idea
+.vscode
+dist
+node_modules
+apify_storage
+storage

--- a/templates/ts-crawlee-playwright-camoufox/README.md
+++ b/templates/ts-crawlee-playwright-camoufox/README.md
@@ -1,9 +1,11 @@
 ## PlaywrightCrawler template
 
-This template is a production ready boilerplate for developing an [Actor](https://apify.com/actors) with `PlaywrightCrawler`. Use this to bootstrap your projects using the most up-to-date code.
+This template is a production-ready boilerplate for developing an [Actor](https://apify.com/actors) with `PlaywrightCrawler`. It has [Camoufox](https://github.com/daijro/camoufox) - a stealthy fork of Firefox - preinstalled. Note that Camoufox might consume more resources than the default Playwright-bundled Chromium or Firefox.
+
+Use this template to bootstrap your projects using the most up-to-date code.
 
 > We decided to split Apify SDK into two libraries, Crawlee and Apify SDK v3. Crawlee will retain all the crawling and scraping-related tools and will always strive to be the best [web scraping](https://apify.com/web-scraping) library for its community. At the same time, Apify SDK will continue to exist, but keep only the Apify-specific features related to building actors on the Apify platform. Read the upgrading guide to learn about the changes.
-> 
+>
 
 ## Resources
 

--- a/templates/ts-crawlee-playwright-camoufox/README.md
+++ b/templates/ts-crawlee-playwright-camoufox/README.md
@@ -1,0 +1,21 @@
+## PlaywrightCrawler template
+
+This template is a production ready boilerplate for developing an [Actor](https://apify.com/actors) with `PlaywrightCrawler`. Use this to bootstrap your projects using the most up-to-date code.
+
+> We decided to split Apify SDK into two libraries, Crawlee and Apify SDK v3. Crawlee will retain all the crawling and scraping-related tools and will always strive to be the best [web scraping](https://apify.com/web-scraping) library for its community. At the same time, Apify SDK will continue to exist, but keep only the Apify-specific features related to building actors on the Apify platform. Read the upgrading guide to learn about the changes.
+> 
+
+## Resources
+
+If you're looking for examples or want to learn more visit:
+
+- [Crawlee + Apify Platform guide](https://crawlee.dev/docs/guides/apify-platform)
+- [Documentation](https://crawlee.dev/api/playwright-crawler/class/PlaywrightCrawler) and [examples](https://crawlee.dev/docs/examples/playwright-crawler)
+- [Node.js tutorials](https://docs.apify.com/academy/node-js) in Academy
+- [Scraping single-page applications with Playwright](https://blog.apify.com/scraping-single-page-applications-with-playwright/)
+- [How to scale Puppeteer and Playwright](https://blog.apify.com/how-to-scale-puppeteer-and-playwright/)
+- [Integration with Zapier](https://apify.com/integrations), Make, GitHub, Google Drive and other apps
+- [Video guide on getting scraped data using Apify API](https://www.youtube.com/watch?v=ViYYDHSBAKM)
+- A short guide on how to build web scrapers using code templates:
+
+[web scraper template](https://www.youtube.com/watch?v=u-i-Korzf8w)

--- a/templates/ts-crawlee-playwright-camoufox/package.json
+++ b/templates/ts-crawlee-playwright-camoufox/package.json
@@ -1,0 +1,36 @@
+{
+    "name": "crawlee-playwright-typescript-camoufox",
+    "version": "0.0.1",
+    "type": "module",
+    "description": "This is an example of an Apify actor.",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "dependencies": {
+        "apify": "^3.2.6",
+        "camoufox-js": "^0.1.3",
+        "crawlee": "^3.11.5",
+        "playwright": "*"
+    },
+    "devDependencies": {
+        "@apify/eslint-config-ts": "^0.3.0",
+        "@apify/tsconfig": "^0.1.0",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
+        "eslint": "^8.50.0",
+        "tsx": "^4.6.2",
+        "typescript": "^5.3.3"
+    },
+    "scripts": {
+        "start": "npm run start:dev",
+        "start:prod": "node dist/main.js",
+        "start:dev": "tsx src/main.ts",
+        "build": "tsc",
+        "lint": "eslint ./src --ext .ts",
+        "lint:fix": "eslint ./src --ext .ts --fix",
+        "test": "echo \"Error: oops, the actor has no tests yet, sad!\" && exit 1",
+        "postinstall": "npx crawlee install-playwright-browsers"
+    },
+    "author": "It's not you it's me",
+    "license": "ISC"
+}

--- a/templates/ts-crawlee-playwright-camoufox/package.json
+++ b/templates/ts-crawlee-playwright-camoufox/package.json
@@ -4,7 +4,7 @@
     "type": "module",
     "description": "This is an example of an Apify actor.",
     "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
     },
     "dependencies": {
         "apify": "^3.2.6",

--- a/templates/ts-crawlee-playwright-camoufox/src/main.ts
+++ b/templates/ts-crawlee-playwright-camoufox/src/main.ts
@@ -38,6 +38,7 @@ const crawler = new PlaywrightCrawler({
     launchContext: {
         launcher: firefox,
         launchOptions: await camoufoxLaunchOptions({
+            headless: true,
             // fonts: ['Times New Roman'] // <- custom Camoufox options
             args: ['--disable-gpu'], // Mitigates the "crashing GPU process" issue in Docker containers
         }),

--- a/templates/ts-crawlee-playwright-camoufox/src/main.ts
+++ b/templates/ts-crawlee-playwright-camoufox/src/main.ts
@@ -40,7 +40,6 @@ const crawler = new PlaywrightCrawler({
         launchOptions: await camoufoxLaunchOptions({
             headless: true,
             // fonts: ['Times New Roman'] // <- custom Camoufox options
-            args: ['--disable-gpu'], // Mitigates the "crashing GPU process" issue in Docker containers
         }),
     }
 });

--- a/templates/ts-crawlee-playwright-camoufox/src/main.ts
+++ b/templates/ts-crawlee-playwright-camoufox/src/main.ts
@@ -1,0 +1,50 @@
+/**
+ * This template is a production ready boilerplate for developing with `PlaywrightCrawler`.
+ * Use this to bootstrap your projects using the most up-to-date code.
+ * If you're looking for examples or want to learn more, see README.
+ */
+
+// For more information, see https://docs.apify.com/sdk/js
+import { Actor } from 'apify';
+// For more information, see https://crawlee.dev
+import { PlaywrightCrawler } from 'crawlee';
+// this is ESM project, and as such, it requires you to specify extensions in your relative imports
+// read more about this here: https://nodejs.org/docs/latest-v18.x/api/esm.html#mandatory-file-extensions
+// note that we need to use `.js` even when inside TS files
+import { router } from './routes.js';
+import { firefox } from 'playwright';
+import { launchOptions as camoufoxLaunchOptions } from 'camoufox-js';
+
+interface Input {
+    startUrls: string[];
+    maxRequestsPerCrawl: number;
+}
+
+// Initialize the Apify SDK
+await Actor.init();
+
+// Structure of input is defined in input_schema.json
+const {
+    startUrls = ['https://crawlee.dev'],
+    maxRequestsPerCrawl = 100,
+} = await Actor.getInput<Input>() ?? {} as Input;
+
+const proxyConfiguration = await Actor.createProxyConfiguration();
+
+const crawler = new PlaywrightCrawler({
+    proxyConfiguration,
+    maxRequestsPerCrawl,
+    requestHandler: router,
+    launchContext: {
+        launcher: firefox,
+        launchOptions: await camoufoxLaunchOptions({
+            // fonts: ['Times New Roman'] // <- custom Camoufox options
+            args: ['--disable-gpu'], // Mitigates the "crashing GPU process" issue in Docker containers
+        }),
+    }
+});
+
+await crawler.run(startUrls);
+
+// Exit successfully
+await Actor.exit();

--- a/templates/ts-crawlee-playwright-camoufox/src/routes.ts
+++ b/templates/ts-crawlee-playwright-camoufox/src/routes.ts
@@ -1,0 +1,21 @@
+import { Dataset, createPlaywrightRouter } from 'crawlee';
+
+export const router = createPlaywrightRouter();
+
+router.addDefaultHandler(async ({ enqueueLinks, log }) => {
+    log.info(`enqueueing new URLs`);
+    await enqueueLinks({
+        globs: ['https://apify.com/*'],
+        label: 'detail',
+    });
+});
+
+router.addHandler('detail', async ({ request, page, log }) => {
+    const title = await page.title();
+    log.info(`${title}`, { url: request.loadedUrl });
+
+    await Dataset.pushData({
+        url: request.loadedUrl,
+        title,
+    });
+});

--- a/templates/ts-crawlee-playwright-camoufox/tsconfig.json
+++ b/templates/ts-crawlee-playwright-camoufox/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "extends": "@apify/tsconfig",
+    "compilerOptions": {
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "target": "ES2022",
+        "outDir": "dist",
+        "noUnusedLocals": false,
+        "skipLibCheck": true,
+        "lib": ["DOM"]
+    },
+    "include": [
+        "./src/**/*"
+    ]
+}


### PR DESCRIPTION
Following the https://github.com/apify/apify-sdk-js/pull/364 and https://github.com/apify/crawlee/pull/2842 , this PR adds Camoufox-enabled templates to Apify Actor templates. The implementation is heavily based on the existing Playwright + Chrome templates.

The only issue (I'm aware of) currently is the immense size of those images (as they contain Chrome and we add Camoufox binaries). Installing Camoufox directly to a `node-debian` image results in missing system dependencies. While it might be possible to install those manually in the Dockerfile, it might make the Dockerfile too complex for a regular user.

![image](https://github.com/user-attachments/assets/fb0050fd-fadc-4bbc-80f3-0681dcfa2b92)
