### PR TITLE
fix: install `Camoufox` browsers in TS Camoufox template

### DIFF
--- a/templates/ts-crawlee-playwright-camoufox/package.json
+++ b/templates/ts-crawlee-playwright-camoufox/package.json
@@ -29,7 +29,7 @@
         "lint": "eslint ./src --ext .ts",
         "lint:fix": "eslint ./src --ext .ts --fix",
         "test": "echo \"Error: oops, the actor has no tests yet, sad!\" && exit 1",
-        "postinstall": "npx crawlee install-playwright-browsers"
+        "postinstall": "npx camoufox-js fetch"
     },
     "author": "It's not you it's me",
     "license": "ISC"


### PR DESCRIPTION
The previous state was a result of a copy-paste error from other Playwright templates. This aligns the `ts-crawlee-playwright-camoufox` with the `js-crawlee-playwright-camoufox` template.