### PR TITLE
fix: do not skip `camoufox` install in Docker build

### DIFF
--- a/templates/js-crawlee-playwright-camoufox/.actor/Dockerfile
+++ b/templates/js-crawlee-playwright-camoufox/.actor/Dockerfile
@@ -10,6 +10,8 @@ RUN npm ls crawlee apify playwright
 # to speed up the build using Docker layer cache.
 COPY --chown=myuser package*.json ./
 
+# Ensure we'll install Camoufox using the npm postinstall script
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0
 # Install NPM packages, skip optional and development dependencies to
 # keep the image small. Avoid logging too much and print the dependency
 # tree for debugging

--- a/templates/js-crawlee-playwright-camoufox/package.json
+++ b/templates/js-crawlee-playwright-camoufox/package.json
@@ -8,7 +8,7 @@
     },
     "dependencies": {
         "apify": "^3.2.6",
-        "camoufox-js": "^0.1.3",
+        "camoufox-js": "^0.2.1",
         "crawlee": "^3.11.5",
         "playwright": "*"
     },

--- a/templates/ts-crawlee-playwright-camoufox/.actor/Dockerfile
+++ b/templates/ts-crawlee-playwright-camoufox/.actor/Dockerfile
@@ -31,6 +31,8 @@ RUN npm ls crawlee apify puppeteer playwright
 # to speed up the build using Docker layer cache.
 COPY --chown=myuser package*.json ./
 
+# Ensure we'll install Camoufox using the npm postinstall script
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0
 # Install NPM packages, skip optional and development dependencies to
 # keep the image small. Avoid logging too much and print the dependency
 # tree for debugging
@@ -43,8 +45,6 @@ RUN npm --quiet set progress=false \
     && echo "NPM version:" \
     && npm --version \
     && rm -r ~/.npm
-
-RUN npx camoufox-js fetch
 
 # Copy built JS files from builder image
 COPY --from=builder --chown=myuser /home/myuser/dist ./dist

--- a/templates/ts-crawlee-playwright-camoufox/package.json
+++ b/templates/ts-crawlee-playwright-camoufox/package.json
@@ -8,7 +8,7 @@
     },
     "dependencies": {
         "apify": "^3.2.6",
-        "camoufox-js": "^0.1.3",
+        "camoufox-js": "^0.2.1",
         "crawlee": "^3.11.5",
         "playwright": "*"
     },


### PR DESCRIPTION
Updates `camoufox-js` in templates to the latest version. This now respects the `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` flag. We need to disable this in the Dockerfiles, as the base images set this flag to `1`.