### PR TITLE
fix: Fix docker build of Python Crawlee templates

### DIFF
--- a/templates/python-beautifulsoup/.actor/Dockerfile
+++ b/templates/python-beautifulsoup/.actor/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "Python version:" \
 COPY . ./
 
 # Use compileall to ensure the runnability of the Actor Python code.
-RUN python3 -m compileall -q .
+RUN python3 -m compileall -q src/
 
 # Create and run as a non-root user.
 RUN useradd --create-home apify && \

--- a/templates/python-crawlee-beautifulsoup/.actor/Dockerfile
+++ b/templates/python-crawlee-beautifulsoup/.actor/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "Python version:" \
 COPY . ./
 
 # Use compileall to ensure the runnability of the Actor Python code.
-RUN python3 -m compileall -q .
+RUN python3 -m compileall -q src/
 
 # Create and run as a non-root user.
 RUN useradd --create-home apify && \

--- a/templates/python-crawlee-playwright/.actor/Dockerfile
+++ b/templates/python-crawlee-playwright/.actor/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "Python version:" \
 COPY . ./
 
 # Use compileall to ensure the runnability of the Actor Python code.
-RUN python3 -m compileall -q .
+RUN python3 -m compileall -q src/
 
 # Specify how to launch the source code of your Actor.
 # By default, the "python3 -m src" command is run

--- a/templates/python-crewai/.actor/Dockerfile
+++ b/templates/python-crewai/.actor/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "Python version:" \
 COPY . ./
 
 # Use compileall to ensure the runnability of the Actor Python code.
-RUN python3 -m compileall -q .
+RUN python3 -m compileall -q src/
 
 # Create and run as a non-root user.
 RUN useradd --create-home apify && \

--- a/templates/python-empty/.actor/Dockerfile
+++ b/templates/python-empty/.actor/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "Python version:" \
 COPY . ./
 
 # Use compileall to ensure the runnability of the Actor Python code.
-RUN python3 -m compileall -q .
+RUN python3 -m compileall -q src/
 
 # Create and run as a non-root user.
 RUN useradd --create-home apify && \

--- a/templates/python-langgraph/.actor/Dockerfile
+++ b/templates/python-langgraph/.actor/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "Python version:" \
 COPY . ./
 
 # Use compileall to ensure the runnability of the Actor Python code.
-RUN python3 -m compileall -q .
+RUN python3 -m compileall -q src/
 
 # Create and run as a non-root user.
 RUN useradd --create-home apify && \

--- a/templates/python-llamaindex-agent/.actor/Dockerfile
+++ b/templates/python-llamaindex-agent/.actor/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "Python version:" \
 COPY . ./
 
 # Use compileall to ensure the runnability of the Actor Python code.
-RUN python3 -m compileall -q .
+RUN python3 -m compileall -q src/
 
 # Create and run as a non-root user.
 RUN useradd --create-home apify && \

--- a/templates/python-playwright/.actor/Dockerfile
+++ b/templates/python-playwright/.actor/Dockerfile
@@ -30,7 +30,7 @@ RUN playwright install-deps && \
 COPY . ./
 
 # Use compileall to ensure the runnability of the Actor Python code.
-RUN python3 -m compileall -q .
+RUN python3 -m compileall -q src/
 
 # Specify how to launch the source code of your Actor.
 # By default, the "python3 -m src" command is run

--- a/templates/python-scrapy/.actor/Dockerfile
+++ b/templates/python-scrapy/.actor/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "Python version:" \
 COPY . ./
 
 # Use compileall to ensure the runnability of the Actor Python code.
-RUN python3 -m compileall -q .
+RUN python3 -m compileall -q src/
 
 # Create and run as a non-root user.
 RUN useradd --create-home apify && \

--- a/templates/python-selenium/.actor/Dockerfile
+++ b/templates/python-selenium/.actor/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "Python version:" \
 COPY . ./
 
 # Use compileall to ensure the runnability of the Actor Python code.
-RUN python3 -m compileall -q .
+RUN python3 -m compileall -q src/
 
 # Specify how to launch the source code of your Actor.
 # By default, the "python3 -m src" command is run

--- a/templates/python-standby/.actor/Dockerfile
+++ b/templates/python-standby/.actor/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "Python version:" \
 COPY . ./
 
 # Use compileall to ensure the runnability of the Actor Python code.
-RUN python3 -m compileall -q .
+RUN python3 -m compileall -q src/
 
 # Create and run as a non-root user.
 RUN useradd --create-home apify && \

--- a/templates/python-start/.actor/Dockerfile
+++ b/templates/python-start/.actor/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "Python version:" \
 COPY . ./
 
 # Use compileall to ensure the runnability of the Actor Python code.
-RUN python3 -m compileall -q .
+RUN python3 -m compileall -q src/
 
 # Create and run as a non-root user.
 RUN useradd --create-home apify && \

--- a/wrappers/python-scrapy/.actor/Dockerfile.template
+++ b/wrappers/python-scrapy/.actor/Dockerfile.template
@@ -26,7 +26,7 @@ RUN echo "Python version:" \
 COPY . ./
 
 # Use compileall to ensure the runnability of the Actor Python code.
-RUN python3 -m compileall -q .
+RUN python3 -m compileall -q src/
 
 # Specify how to launch the source code of your Actor.
 # By default, the "python3 -m src" command is run


### PR DESCRIPTION
If we use:

```
RUN python3 -m compileall -q .
```

as a result, it will be executed on `site-packages` as well, resulting in:

![image](https://github.com/user-attachments/assets/99dc4d23-3609-4451-80c1-c84eedb35d1d)

since we have cookie-cutter templates inside.