### PR TITLE
chore: bump Camoufox version

### DIFF
--- a/templates/js-crawlee-playwright-camoufox/package.json
+++ b/templates/js-crawlee-playwright-camoufox/package.json
@@ -8,7 +8,7 @@
     },
     "dependencies": {
         "apify": "^3.2.6",
-        "camoufox-js": "^0.2.1",
+        "camoufox-js": "^0.3.5",
         "crawlee": "^3.11.5",
         "playwright": "*"
     },

--- a/templates/ts-crawlee-playwright-camoufox/package.json
+++ b/templates/ts-crawlee-playwright-camoufox/package.json
@@ -8,7 +8,7 @@
     },
     "dependencies": {
         "apify": "^3.2.6",
-        "camoufox-js": "^0.2.1",
+        "camoufox-js": "^0.3.5",
         "crawlee": "^3.11.5",
         "playwright": "*"
     },


### PR DESCRIPTION
Bumps Camoufox in the respective templates to the latest version available. This enables the template users to use the latest patches from `camoufox-js`.