### PR TITLE
fix: remove stray "main" field in the `ts-playwright-test-runner` test

### DIFF
--- a/templates/ts-playwright-test-runner/package.json
+++ b/templates/ts-playwright-test-runner/package.json
@@ -2,7 +2,6 @@
     "name": "playwright-test",
     "version": "1.0.0",
     "description": "",
-    "main": "src/index.ts",
     "scripts": {
         "start": "npm run start:dev",
         "start:dev": "tsx src/main.ts",


### PR DESCRIPTION
Because of [recent changes](https://github.com/apify/apify-cli/blame/d8ef00071c4138a441dec2d5336bba51b3143708/src/lib/hooks/useCwdProject.ts#L147) in Apify CLI, the stray `"main"` field in `ts-playwright-test-runner`'s package.json file caused the test to fail.

This would have caused problems for any users running the template-initialized test with `npx apify-cli run`.