### PR TITLE
fix: Correct the type for `startUrls` input in TypeScript templates

### DIFF
--- a/templates/ts-crawlee-cheerio/src/main.ts
+++ b/templates/ts-crawlee-cheerio/src/main.ts
@@ -9,7 +9,12 @@ import { CheerioCrawler, Dataset } from 'crawlee';
 // import { router } from './routes.js';
 
 interface Input {
-    startUrls: string[];
+    startUrls: {
+        url: string;
+        method?: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'TRACE' | 'OPTIONS' | 'CONNECT' | 'PATCH';
+        headers?: Record<string, string>;
+        userData: Record<string, unknown>;
+    }[];
     maxRequestsPerCrawl: number;
 }
 

--- a/templates/ts-crawlee-playwright-camoufox/src/main.ts
+++ b/templates/ts-crawlee-playwright-camoufox/src/main.ts
@@ -17,7 +17,12 @@ import { firefox } from 'playwright';
 import { router } from './routes.js';
 
 interface Input {
-    startUrls: string[];
+    startUrls: {
+        url: string;
+        method?: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'TRACE' | 'OPTIONS' | 'CONNECT' | 'PATCH';
+        headers?: Record<string, string>;
+        userData: Record<string, unknown>;
+    }[];
     maxRequestsPerCrawl: number;
 }
 

--- a/templates/ts-crawlee-playwright-chrome/src/main.ts
+++ b/templates/ts-crawlee-playwright-chrome/src/main.ts
@@ -15,7 +15,12 @@ import { PlaywrightCrawler } from 'crawlee';
 import { router } from './routes.js';
 
 interface Input {
-    startUrls: string[];
+    startUrls: {
+        url: string;
+        method?: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'TRACE' | 'OPTIONS' | 'CONNECT' | 'PATCH';
+        headers?: Record<string, string>;
+        userData: Record<string, unknown>;
+    }[];
     maxRequestsPerCrawl: number;
 }
 

--- a/templates/ts-crawlee-puppeteer-chrome/src/main.ts
+++ b/templates/ts-crawlee-puppeteer-chrome/src/main.ts
@@ -1,7 +1,6 @@
 // Apify SDK - toolkit for building Apify Actors (Read more at https://docs.apify.com/sdk/js/).
 import { Actor } from 'apify';
 // Web scraping and browser automation library (Read more at https://crawlee.dev)
-import type { Request } from 'crawlee';
 import { PuppeteerCrawler } from 'crawlee';
 
 import { router } from './routes.js';
@@ -10,7 +9,12 @@ import { router } from './routes.js';
 await Actor.init();
 
 interface Input {
-    startUrls: Request[];
+    startUrls: {
+        url: string;
+        method?: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'TRACE' | 'OPTIONS' | 'CONNECT' | 'PATCH';
+        headers?: Record<string, string>;
+        userData: Record<string, unknown>;
+    }[];
 }
 // Define the URLs to start the crawler with - get them from the input of the Actor or use a default list.
 const { startUrls = ['https://apify.com'] } = (await Actor.getInput<Input>()) ?? {};


### PR DESCRIPTION
The `requestListSources` editor in the Actor input creates objects with URLs, not just string arrays. The types in the templates didn't match that.