### PR TITLE
fix: change ts-mcp-template server to @modelcontextprotocol/server-everything

### DIFF
--- a/templates/ts-mcp-server/README.md
+++ b/templates/ts-mcp-server/README.md
@@ -6,7 +6,7 @@ This allows you to run any stdio MCP server as a [standby Actor](https://docs.ap
 ## How to use
 
 Change the `MCP_COMMAND` to spawn your stdio MCP server in `src/main.ts`, and don't forget to install the required MCP server in the `package.json` (using `npm install ...`).
-By default, this template runs a [Everything MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/everything) server using the following command:
+By default, this template runs an [Everything MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/everything) using the following command:
 
 ```
 npx @modelcontextprotocol/server-everything

--- a/templates/ts-mcp-server/README.md
+++ b/templates/ts-mcp-server/README.md
@@ -6,10 +6,10 @@ This allows you to run any stdio MCP server as a [standby Actor](https://docs.ap
 ## How to use
 
 Change the `MCP_COMMAND` to spawn your stdio MCP server in `src/main.ts`, and don't forget to install the required MCP server in the `package.json` (using `npm install ...`).
-By default, this template runs a [Sequential Thinking MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking) server using the following command:
+By default, this template runs a [Everything MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/everything) server using the following command:
 
 ```
-npx @modelcontextprotocol/server-sequential-thinking
+npx @modelcontextprotocol/server-everything
 ```
 
 Feel free to configure billing logic in `.actor/pay_per_event.json` and `src/billing.ts`.

--- a/templates/ts-mcp-server/package.json
+++ b/templates/ts-mcp-server/package.json
@@ -8,7 +8,7 @@
     },
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.4",
-        "@modelcontextprotocol/server-sequential-thinking": "^0.6.2",
+        "@modelcontextprotocol/server-everything": "^2025.5.12",
         "apify": "^3.4.1",
         "body-parser": "^2.2.0",
         "express": "^5.1.0"

--- a/templates/ts-mcp-server/src/main.ts
+++ b/templates/ts-mcp-server/src/main.ts
@@ -17,7 +17,7 @@ import { getLogger } from './lib/getLogger.js';
 // import { router } from './routes.js';
 
 // Configuration constants for the MCP server
-// Command to run the Sequential Thinking MCP server
+// Command to run the Everything MCP Server
 // TODO: Do not forget to install the MCP server in package.json (using `npm install ...`)
 const MCP_COMMAND = 'npx @modelcontextprotocol/server-everything';
 

--- a/templates/ts-mcp-server/src/main.ts
+++ b/templates/ts-mcp-server/src/main.ts
@@ -19,7 +19,7 @@ import { getLogger } from './lib/getLogger.js';
 // Configuration constants for the MCP server
 // Command to run the Sequential Thinking MCP server
 // TODO: Do not forget to install the MCP server in package.json (using `npm install ...`)
-const MCP_COMMAND = 'npx @modelcontextprotocol/server-sequential-thinking';
+const MCP_COMMAND = 'npx @modelcontextprotocol/server-everything';
 
 // Check if the Actor is running in standby mode
 const STANDBY_MODE = process.env.APIFY_META_ORIGIN === 'STANDBY';


### PR DESCRIPTION
The @modelcontextprotocol/server-sequential-thinking was confusing for human users, changed MCP server to @modelcontextprotocol/server-everything which is more human user friendly