### PR TITLE
fix: puppeteer templates that failed on README.md npm run format and ignore venv/.venv and node_modules in eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,7 @@ import apifyJs from '@apify/eslint-config/js.js';
 
 // eslint-disable-next-line import/no-default-export
 export default [
-    { ignores: ['**/dist', 'templates', 'src'] },
+    { ignores: ['**/dist', '**/venv', '**/.venv', 'templates', 'src', 'node_modules'] },
     ...apifyJs,
     prettier,
     {

--- a/templates/js-crawlee-puppeteer-chrome/README.md
+++ b/templates/js-crawlee-puppeteer-chrome/README.md
@@ -23,7 +23,6 @@ If you're looking for examples or want to learn more visit:
     - `proxyConfiguration` - provide the proxy configuration to the crawler
     - `requestHandler` - handle each request with custom router defined in the `routes.js` file.
 4. Handle requests with the custom router from `routes.js` file. Read more about custom routing for the Cheerio Crawler [here](https://crawlee.dev/api/puppeteer-crawler/function/createPuppeteerRouter)
-
     - Create a new router instance with `new createPuppeteerRouter()`
     - Define default handler that will be called for all URLs that are not handled by other handlers by adding `router.addDefaultHandler(() => { ... })`
     - Define additional handlers - here you can add your own handling of the page

--- a/templates/ts-crawlee-puppeteer-chrome/README.md
+++ b/templates/ts-crawlee-puppeteer-chrome/README.md
@@ -23,7 +23,6 @@ If you're looking for examples or want to learn more visit:
     - `proxyConfiguration` - provide the proxy configuration to the crawler
     - `requestHandler` - handle each request with custom router defined in the `routes.ts` file.
 4. Handle requests with the custom router from `routes.ts` file. Read more about custom routing for the Cheerio Crawler [here](https://crawlee.dev/api/puppeteer-crawler/function/createPuppeteerRouter)
-
     - Create a new router instance with `new createPuppeteerRouter()`
     - Define default handler that will be called for all URLs that are not handled by other handlers by adding `router.addDefaultHandler(() => { ... })`
     - Define additional handlers - here you can add your own handling of the page


### PR DESCRIPTION
in my previous PR https://github.com/apify/actor-templates/pull/448 the puppeteer templates were failing on npm run format README.md check I fixed that formatting issue. Also noticed that when running eslint in the root it fails on venv and .venv dirs so I added them to ignore (also added node_modules just in case).