### PR TITLE
feat(python-mcp-server): add streamable HTTP /mcp endpoint

### DIFF
--- a/templates/python-mcp-server/.actor/actor.json
+++ b/templates/python-mcp-server/.actor/actor.json
@@ -18,5 +18,5 @@
         "required": []
     },
     "dockerfile": "../Dockerfile",
-    "webServerMcpPath": "/sse"
+    "webServerMcpPath": "/sse,/mcp"
 }

--- a/templates/python-mcp-server/README.md
+++ b/templates/python-mcp-server/README.md
@@ -5,7 +5,7 @@ A Python template for deploying and monetizing a [Model Context Protocol (MCP)](
 This template enables you to:
 
 - Deploy any Python stdio MCP server (e.g., [ArXiv MCP Server](https://github.com/blazickjp/arxiv-mcp-server)), or connect to an existing remote MCP server using SSE transport
-- Expose your MCP server via Server-Sent Events (SSE) transport
+- Expose your MCP server via [legacy Server-Sent Events (SSE)](https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse) or [streamable HTTP](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http) transport
 - Monetize your server using Apify's Pay Per Event (PPE) model
 
 ## ✨ Features
@@ -39,15 +39,26 @@ This template enables you to:
 2. Add any required dependencies to the `requirements.txt` file (e.g. [arxiv-mcp-server](https://github.com/blazickjp/arxiv-mcp-server)).
 3. Deploy to Apify and enable standby mode.
 4. Connect using an MCP client:
-    ```json
-    {
-        "mcpServers": {
-            "your-server": {
-                "url": "https://your-actor.apify.actor/sse"
+    - Using [streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http):
+        ```json
+        {
+            "mcpServers": {
+                "your-server": {
+                    "url": "https://your-actor.apify.actor/mcp"
+                }
             }
         }
-    }
-    ```
+        ```
+    - Using [legacy SSE transport](https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse):
+        ```json
+        {
+            "mcpServers": {
+                "your-server": {
+                    "url": "https://your-actor.apify.actor/sse"
+                }
+            }
+        }
+        ```
 
 ## 💰 Pricing
 
@@ -85,7 +96,7 @@ To set up the PPE model:
 
 ## 🔧 How It Works
 
-This template implements a proxy server that can connect to either a stdio-based or SSE-based MCP server and expose it via SSE transport. Here's how it works:
+This template implements a proxy server that can connect to either a stdio-based or SSE-based MCP server and expose it via [legacy Server-Sent Events (SSE) transport](https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse) or [streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http). Here's how it works:
 
 ### Server types
 
@@ -133,7 +144,7 @@ Environment variables can be securely stored and managed at the Actor level on t
 
 The proxy server (`ProxyServer` class) handles:
 
-- Creating a Starlette web server with SSE endpoints (`/sse` and `/messages/`)
+- Creating a Starlette web server with legacy SSE (`/sse` and `/messages/`) and streamable HTTP (`/mcp`) endpoints
 - Managing connections to the underlying MCP server
 - Forwarding requests and responses between clients and the MCP server
 - Handling charging through the `actor_charge_function`

--- a/templates/python-mcp-server/src/event_store.py
+++ b/templates/python-mcp-server/src/event_store.py
@@ -37,9 +37,9 @@ class InMemoryEventStore(EventStore):
     where a persistent storage solution would be more appropriate.
 
     This implementation keeps only the last N events per stream for memory efficiency.
-    """ # noqa: D205
+    """  # noqa: D205
 
-    def __init__(self, max_events_per_stream: int = 100): # noqa: ANN204
+    def __init__(self, max_events_per_stream: int = 100):  # noqa: ANN204
         """Initialize the event store.
 
         Args:
@@ -52,7 +52,7 @@ class InMemoryEventStore(EventStore):
         self.event_index: dict[EventId, EventEntry] = {}
 
     async def store_event(self, stream_id: StreamId, message: JSONRPCMessage) -> EventId:
-        """Stores an event with a generated event ID.""" # noqa: D401
+        """Stores an event with a generated event ID."""  # noqa: D401
         event_id = str(uuid4())
         event_entry = EventEntry(event_id=event_id, stream_id=stream_id, message=message)
 

--- a/templates/python-mcp-server/src/event_store.py
+++ b/templates/python-mcp-server/src/event_store.py
@@ -1,6 +1,5 @@
 # Source https://github.com/modelcontextprotocol/python-sdk/blob/3978c6e1b91e8830e82d97ab3c4e3b6559972021/examples/servers/simple-streamablehttp/mcp_simple_streamablehttp/event_store.py
-"""
-In-memory event store for demonstrating resumability functionality.
+"""In-memory event store for demonstrating resumability functionality.
 
 This is a simple implementation intended for examples and testing,
 not for production use where a persistent storage solution would be more appropriate.
@@ -25,9 +24,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class EventEntry:
-    """
-    Represents an event entry in the event store.
-    """
+    """Represents an event entry in the event store."""
 
     event_id: EventId
     stream_id: StreamId
@@ -35,15 +32,14 @@ class EventEntry:
 
 
 class InMemoryEventStore(EventStore):
-    """
-    Simple in-memory implementation of the EventStore interface for resumability.
+    """Simple in-memory implementation of the EventStore interface for resumability.
     This is primarily intended for examples and testing, not for production use
     where a persistent storage solution would be more appropriate.
 
     This implementation keeps only the last N events per stream for memory efficiency.
-    """
+    """ # noqa: D205
 
-    def __init__(self, max_events_per_stream: int = 100):
+    def __init__(self, max_events_per_stream: int = 100): # noqa: ANN204
         """Initialize the event store.
 
         Args:
@@ -55,14 +51,10 @@ class InMemoryEventStore(EventStore):
         # event_id -> EventEntry for quick lookup
         self.event_index: dict[EventId, EventEntry] = {}
 
-    async def store_event(
-        self, stream_id: StreamId, message: JSONRPCMessage
-    ) -> EventId:
-        """Stores an event with a generated event ID."""
+    async def store_event(self, stream_id: StreamId, message: JSONRPCMessage) -> EventId:
+        """Stores an event with a generated event ID.""" # noqa: D401
         event_id = str(uuid4())
-        event_entry = EventEntry(
-            event_id=event_id, stream_id=stream_id, message=message
-        )
+        event_entry = EventEntry(event_id=event_id, stream_id=stream_id, message=message)
 
         # Get or create deque for this stream
         if stream_id not in self.streams:
@@ -87,7 +79,7 @@ class InMemoryEventStore(EventStore):
     ) -> StreamId | None:
         """Replays events that occurred after the specified event ID."""
         if last_event_id not in self.event_index:
-            logger.warning(f"Event ID {last_event_id} not found in store")
+            logger.warning(f'Event ID {last_event_id} not found in store')
             return None
 
         # Get the stream and find events after the last one

--- a/templates/python-mcp-server/src/event_store.py
+++ b/templates/python-mcp-server/src/event_store.py
@@ -1,0 +1,106 @@
+# Source https://github.com/modelcontextprotocol/python-sdk/blob/3978c6e1b91e8830e82d97ab3c4e3b6559972021/examples/servers/simple-streamablehttp/mcp_simple_streamablehttp/event_store.py
+"""
+In-memory event store for demonstrating resumability functionality.
+
+This is a simple implementation intended for examples and testing,
+not for production use where a persistent storage solution would be more appropriate.
+"""
+
+import logging
+from collections import deque
+from dataclasses import dataclass
+from uuid import uuid4
+
+from mcp.server.streamable_http import (
+    EventCallback,
+    EventId,
+    EventMessage,
+    EventStore,
+    StreamId,
+)
+from mcp.types import JSONRPCMessage
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EventEntry:
+    """
+    Represents an event entry in the event store.
+    """
+
+    event_id: EventId
+    stream_id: StreamId
+    message: JSONRPCMessage
+
+
+class InMemoryEventStore(EventStore):
+    """
+    Simple in-memory implementation of the EventStore interface for resumability.
+    This is primarily intended for examples and testing, not for production use
+    where a persistent storage solution would be more appropriate.
+
+    This implementation keeps only the last N events per stream for memory efficiency.
+    """
+
+    def __init__(self, max_events_per_stream: int = 100):
+        """Initialize the event store.
+
+        Args:
+            max_events_per_stream: Maximum number of events to keep per stream
+        """
+        self.max_events_per_stream = max_events_per_stream
+        # for maintaining last N events per stream
+        self.streams: dict[StreamId, deque[EventEntry]] = {}
+        # event_id -> EventEntry for quick lookup
+        self.event_index: dict[EventId, EventEntry] = {}
+
+    async def store_event(
+        self, stream_id: StreamId, message: JSONRPCMessage
+    ) -> EventId:
+        """Stores an event with a generated event ID."""
+        event_id = str(uuid4())
+        event_entry = EventEntry(
+            event_id=event_id, stream_id=stream_id, message=message
+        )
+
+        # Get or create deque for this stream
+        if stream_id not in self.streams:
+            self.streams[stream_id] = deque(maxlen=self.max_events_per_stream)
+
+        # If deque is full, the oldest event will be automatically removed
+        # We need to remove it from the event_index as well
+        if len(self.streams[stream_id]) == self.max_events_per_stream:
+            oldest_event = self.streams[stream_id][0]
+            self.event_index.pop(oldest_event.event_id, None)
+
+        # Add new event
+        self.streams[stream_id].append(event_entry)
+        self.event_index[event_id] = event_entry
+
+        return event_id
+
+    async def replay_events_after(
+        self,
+        last_event_id: EventId,
+        send_callback: EventCallback,
+    ) -> StreamId | None:
+        """Replays events that occurred after the specified event ID."""
+        if last_event_id not in self.event_index:
+            logger.warning(f"Event ID {last_event_id} not found in store")
+            return None
+
+        # Get the stream and find events after the last one
+        last_event = self.event_index[last_event_id]
+        stream_id = last_event.stream_id
+        stream_events = self.streams.get(last_event.stream_id, deque())
+
+        # Events in deque are already in chronological order
+        found_last = False
+        for event in stream_events:
+            if found_last:
+                await send_callback(EventMessage(event.message, event.event_id))
+            elif event.event_id == last_event_id:
+                found_last = True
+
+        return stream_id

--- a/templates/python-mcp-server/src/main.py
+++ b/templates/python-mcp-server/src/main.py
@@ -22,7 +22,7 @@ from mcp.client.stdio import StdioServerParameters  # noqa: E402
 MCP_SERVER_PARAMS = StdioServerParameters(
     command='uv',
     args=['run', 'arxiv-mcp-server'],
-    env={'YOUR-ENV_VAR': os.getenv('YOUR-ENV-VAR') or ""},  # Optional environment variables
+    env={'YOUR-ENV_VAR': os.getenv('YOUR-ENV-VAR') or ''},  # Optional environment variables
 )
 
 # 2) For SSE server type, you need to provide the url, you can also specify headers if needed with Authorization

--- a/templates/python-mcp-server/src/main.py
+++ b/templates/python-mcp-server/src/main.py
@@ -22,7 +22,7 @@ from mcp.client.stdio import StdioServerParameters  # noqa: E402
 MCP_SERVER_PARAMS = StdioServerParameters(
     command='uv',
     args=['run', 'arxiv-mcp-server'],
-    env={'YOUR-ENV_VAR', os.getenv('YOUR-ENV-VAR')},  # Optional environment variables
+    env={'YOUR-ENV_VAR': os.getenv('YOUR-ENV-VAR') or ""},  # Optional environment variables
 )
 
 # 2) For SSE server type, you need to provide the url, you can also specify headers if needed with Authorization
@@ -70,13 +70,25 @@ async def main() -> None:
             Actor.log.info(f'  - proxy server host: {os.environ.get("ACTOR_STANDBY_URL", HOST)}')
             Actor.log.info(f'  - proxy server port: {PORT}')
 
-            Actor.log.info('Put this in your client config:')
+            Actor.log.info('Put this in your client config to use streamable HTTP transport:')
             Actor.log.info(
                 f"""
                 {{
                     "mcpServers": {{
                         "arxiv-mcp-server": {{
-                            "url": "{url}/sse"
+                            "url": "{url}/mcp",
+                        }}
+                    }}
+                }}
+                """
+            )
+            Actor.log.info('Put this in your client config to use legacy SSE transport:')
+            Actor.log.info(
+                f"""
+                {{
+                    "mcpServers": {{
+                        "arxiv-mcp-server": {{
+                            "url": "{url}/sse",
                         }}
                     }}
                 }}

--- a/templates/python-mcp-server/src/server.py
+++ b/templates/python-mcp-server/src/server.py
@@ -6,16 +6,22 @@ Heavily inspired by: https://github.com/sparfenyuk/mcp-proxy
 from __future__ import annotations
 
 import logging
+import contextlib
 from typing import TYPE_CHECKING, Any
+from collections.abc import AsyncIterator
 
 import uvicorn
 from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.stdio import StdioServerParameters, stdio_client
 from mcp.server.sse import SseServerTransport
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from starlette.applications import Starlette
 from starlette.responses import JSONResponse, Response
 from starlette.routing import Mount, Route
+from .event_store import InMemoryEventStore
+from starlette.types import Receive, Scope, Send
+from starlette.requests import Request
 
 from .models import ServerParameters, ServerType, SseServerParameters
 from .proxy_server import create_proxy_server
@@ -33,7 +39,8 @@ logger = logging.getLogger('apify')
 class ProxyServer:
     """Main class implementing the proxy functionality using MCP SDK.
 
-    This proxy is running Starlette app that exposes /sse and /messages/ endpoints.
+    This proxy runs a Starlette app that exposes /sse and /messages/ endpoints for legacy SSE transport,
+    and a /mcp endpoint for streamable HTTP transport.
     It then connects to stdio or SSE based MCP servers and forwards the messages to the client.
 
     The server can optionally charge for operations using a provided charging function.
@@ -87,6 +94,22 @@ class ProxyServer:
     async def create_starlette_app(mcp_server: Server) -> Starlette:
         """Create a Starlette app (SSE server) that exposes /sse and /messages/ endpoints."""
         transport = SseServerTransport('/messages/')
+        event_store = InMemoryEventStore()
+        session_manager = StreamableHTTPSessionManager(
+            app=mcp_server,
+            event_store=event_store,  # Enable resumability
+            json_response=False,
+        )
+        
+        @contextlib.asynccontextmanager
+        async def lifespan(app: Starlette) -> AsyncIterator[None]:
+            """Context manager for managing session manager lifecycle."""
+            async with session_manager.run():
+                logger.info("Application started with StreamableHTTP session manager!")
+                try:
+                    yield
+                finally:
+                    logger.info("Application shutting down...")
 
         async def handle_root(request: Request) -> st.Response:
             """Handle root endpoint."""
@@ -102,8 +125,12 @@ class ProxyServer:
                 {
                     'status': 'running',
                     'type': 'mcp-server',
-                    'transport': 'sse',
-                    'endpoints': {'sse': '/sse', 'messages': '/messages/'},
+                    'transport': 'sse+streamable-http',
+                    'endpoints': {
+                        'sse': '/sse',
+                        'messages': '/messages/',
+                        'streamableHttp': '/mcp',
+                    },
                 }
             )
 
@@ -118,6 +145,14 @@ class ProxyServer:
                 return Response(status_code=500, content=str(e))
             finally:
                 logger.info('SSE connection closed')
+            # Add Response to prevent the None type error
+            return Response(status_code=204)  # No content response
+
+        # ASGI handler for streamable HTTP connections
+        async def handle_streamable_http(
+            scope: Scope, receive: Receive, send: Send
+        ) -> None:
+            await session_manager.handle_request(scope, receive, send)
 
         return Starlette(
             debug=True,
@@ -125,7 +160,9 @@ class ProxyServer:
                 Route('/', endpoint=handle_root),
                 Route('/sse', endpoint=handle_sse, methods=['GET']),
                 Mount('/messages/', app=transport.handle_post_message),
+                Mount("/mcp", app=handle_streamable_http),
             ],
+            lifespan=lifespan,
         )
 
     async def _run_server(self, app: Starlette) -> None:


### PR DESCRIPTION
Add /mcp endpoint so the standby MCP server Actor support the "new" streamable HTTP transport. Fix None type error when closing SSE connection.