### PR TITLE
feat: enable oauth for mcp templates

### DIFF
--- a/templates/python-mcp-server/requirements.txt
+++ b/templates/python-mcp-server/requirements.txt
@@ -2,6 +2,7 @@ apify<3.0.0
 apify_client<2.0.0
 arxiv-mcp-server==0.2.11
 fastapi==0.116.1
+httpx>=0.24.0
 mcp==1.10.1
 pydantic>=2.0.0
 sse-starlette>=1.8.0

--- a/templates/ts-mcp-server/src/server.ts
+++ b/templates/ts-mcp-server/src/server.ts
@@ -282,6 +282,21 @@ export async function startServer(options: {
     getMcpServer = async () => getMCPServerWithCommand(command);
 
     const app = express();
+    
+    // Redirect to Apify favicon
+    app.get('/favicon.ico', (_req: Request, res: Response) => {
+        res.writeHead(301, { Location: "https://apify.com/favicon.ico" });
+        res.end();
+    });
+
+    // Return the Apify OAuth authorization server metadata to allow the MCP client to authenticate using OAuth
+    app.get('/.well-known/oauth-authorization-server', async (_req: Request, res: Response) => {
+        // Some MCP clients do not follow redirects, so we need to fetch the data and return it directly.
+        const response = await fetch(`https://api.apify.com/.well-known/oauth-authorization-server`);
+        const data = await response.json();
+        res.status(200).json(data);
+    });
+
     app.use(express.json());
 
     // Streamable HTTP endpoints


### PR DESCRIPTION
closes https://github.com/apify/actor-templates/issues/486

This PR adds endpoints to the MCP server templates to allow user to log in using oauth.