### PR TITLE
docs(ts-mcp-server): promote streamable rather than sse

### DIFF
--- a/templates/ts-mcp-server/README.md
+++ b/templates/ts-mcp-server/README.md
@@ -15,15 +15,13 @@ const MCP_COMMAND = [
 ];
 ```
 
-Alternatively, you can use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) tool to turn a remote MCP server into an Actor. For example, to connect to a remote server over SSE with authentication:
+Alternatively, you can use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) tool to turn a remote MCP server into an Actor. For example, to connect to a remote server with authentication:
 
 ```
 const MCP_COMMAND = [
     'npx',
     'mcp-remote',
-    'https://mcp.apify.com/sse',
-    '--transport',
-    'sse-only',
+    'https://mcp.apify.com',
     '--header',
     'Authorization: Bearer TOKEN',
 ];


### PR DESCRIPTION
Change readme to promote streamable transport instead of the legacy SSE one.

closes https://github.com/apify/actor-templates/issues/493