### PR TITLE
fix(ts-mcp-server): bill the legacy SSE endpoints correctly and fix the initialize protocol version client mismatch

### DIFF
--- a/templates/ts-mcp-server/src/main.ts
+++ b/templates/ts-mcp-server/src/main.ts
@@ -26,7 +26,7 @@ const MCP_COMMAND = [
 
 // Check if the Actor is running in standby mode
 const STANDBY_MODE = process.env.APIFY_META_ORIGIN === 'STANDBY';
-const SERVER_PORT = parseInt(process.env.ACTOR_WEB_SERVER_PORT || '', 10);
+const SERVER_PORT = parseInt(process.env.ACTOR_WEB_SERVER_PORT || '3001', 10);
 
 // Initialize the Apify Actor environment
 // The init() call configures the Actor for its environment. It's recommended to start every Actor with an init()

--- a/templates/ts-mcp-server/src/mcp.ts
+++ b/templates/ts-mcp-server/src/mcp.ts
@@ -43,7 +43,7 @@ export async function getMcpServer(command: string[], options?: {
     
     // Spawn MCP proxy client for the stdio MCP server
     const proxyClient = await getMcpProxyClient(command);
-    
+
     // Register request handlers for all client requests
     for (const schema of ClientRequestSchema.options) {
         const method = schema.shape.method.value;
@@ -54,7 +54,8 @@ export async function getMcpServer(command: string[], options?: {
                 // this is needed for mcp-remote servers to work correctly
                 return {
                     capabilities: proxyClient.getServerCapabilities(),
-                    protocolVersion: "2025-06-18",
+                    // Return back the client protocolVersion
+                    protocolVersion: req.params.protocolVersion,
                     serverInfo: {
                       name: "Apify MCP proxy server",
                       title: "Apify MCP proxy server",


### PR DESCRIPTION
When working on the new MCP server, I noticed that in the template we're not charging the legacy SSE endpoints 🤦. There was also an issue with the protocolVersion mismatch that broke the whole MCP server - we need to return the same version that the client sends in the request.