### PR TITLE
chore(ci): skip `ts-playwright-test-runner` CI tests

### DIFF
--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -499,6 +499,7 @@
             "label": "Playwright + Chrome Test Runner",
             "category": "typescript",
             "technologies": ["nodejs", "playwright", "chrome"],
+            "skipTests": true,
             "description": "Example of using the Playwright Test project to run automated website tests in the cloud and display their results. Usable as an API.",
             "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/ts-playwright-test-runner.zip?raw=true",
             "defaultRunOptions": {


### PR DESCRIPTION
`ts-playwright-test-runner` template test fails on `npm install` under Windows 11 / Node 24 with `ECOMPROMISED` ([see e.g. here](https://github.com/apify/actor-templates/actions/runs/19433613745/job/55598569066#step:6:1352)).

This PR skips this test in CI for the time being.

Possibly related to https://github.com/actions/runner-images/issues/13238

