### PR TITLE
fix(ts-mcp-proxy): init proxy client error with undefined tasks capabilities

### DIFF
--- a/templates/ts-mcp-proxy/.actor/actor.json
+++ b/templates/ts-mcp-proxy/.actor/actor.json
@@ -1,13 +1,13 @@
 {
     "actorSpecification": 1,
-    "name": "ts-mcp-server",
-    "title": "TypeScript MCP server",
-    "description": "TypeScript Model Context Protocol server.",
+    "name": "ts-mcp-proxy",
+    "title": "TypeScript MCP proxy",
+    "description": "TypeScript Model Context Protocol proxy.",
     "version": "0.0",
     "buildTag": "latest",
     "usesStandbyMode": true,
     "meta": {
-        "templateId": "ts-mcp-server",
+        "templateId": "ts-mcp-proxy",
         "generatedBy": "<FILL-IN-MODEL>"
     },
     "input": {

--- a/templates/ts-mcp-proxy/src/mcp.ts
+++ b/templates/ts-mcp-proxy/src/mcp.ts
@@ -46,6 +46,7 @@ export async function getMcpServer(
         resources: {},
         completions: {},
         logging: {},
+        tasks: {},
     });
 
     // Spawn MCP proxy client for the stdio MCP server


### PR DESCRIPTION
This issue prevented clients from connecting with the new version of MCP SDK.