### PR TITLE
chore: Update templates for base image: apify/actor-node-puppeteer-chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "mustache": "^4.2.0",
         "playwright": "1.57.0",
         "prettier": "^3.7.4",
-        "puppeteer": "24.34.0",
+        "puppeteer": "24.35.0",
         "semver": "^7.7.2",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.34.1"

--- a/templates/js-crawlee-puppeteer-chrome/Dockerfile
+++ b/templates/js-crawlee-puppeteer-chrome/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-puppeteer-chrome:22-24.34.0
+FROM apify/actor-node-puppeteer-chrome:22-24.35.0
 
 # Check preinstalled packages
 RUN npm ls @crawlee/core apify puppeteer playwright

--- a/templates/js-crawlee-puppeteer-chrome/package.json
+++ b/templates/js-crawlee-puppeteer-chrome/package.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "apify": "^3.5.2",
         "@crawlee/puppeteer": "^3.15.3",
-        "puppeteer": "24.34.0"
+        "puppeteer": "24.35.0"
     },
     "devDependencies": {
         "@apify/eslint-config": "^1.0.0",

--- a/templates/ts-crawlee-puppeteer-chrome/Dockerfile
+++ b/templates/ts-crawlee-puppeteer-chrome/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-puppeteer-chrome:22-24.34.0 AS builder
+FROM apify/actor-node-puppeteer-chrome:22-24.35.0 AS builder
 
 # Check preinstalled packages
 RUN npm ls @crawlee/core apify puppeteer playwright
@@ -25,7 +25,7 @@ COPY --chown=myuser:myuser . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node-puppeteer-chrome:22-24.34.0
+FROM apify/actor-node-puppeteer-chrome:22-24.35.0
 
 # Check preinstalled packages
 RUN npm ls @crawlee/core apify puppeteer playwright

--- a/templates/ts-crawlee-puppeteer-chrome/package.json
+++ b/templates/ts-crawlee-puppeteer-chrome/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "apify": "^3.5.2",
         "@crawlee/puppeteer": "^3.15.3",
-        "puppeteer": "24.34.0"
+        "puppeteer": "24.35.0"
     },
     "devDependencies": {
         "@apify/eslint-config": "^1.0.0",


### PR DESCRIPTION
Automated update of templates for base image `apify/actor-node-puppeteer-chrome`

  **Parameters:**
  - Base Image: `apify/actor-node-puppeteer-chrome`
  - Runtime Version: `22`
  - Module Version: `24.35.0`

  > Generated by [Update Templates](https://github.com/apify/actor-templates/actions/workflows/update-templates.yml) workflow.