### PR TITLE
fix: Use promisified setTimeout to fix ESLint errors

### DIFF
--- a/agent-bases/js.AGENTS.md
+++ b/agent-bases/js.AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```javascript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/agent-bases/ts.AGENTS.md
+++ b/agent-bases/ts.AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```typescript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/js-bootstrap-cheerio-crawler/AGENTS.md
+++ b/templates/js-bootstrap-cheerio-crawler/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```javascript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/js-crawlee-cheerio/AGENTS.md
+++ b/templates/js-crawlee-cheerio/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```javascript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/js-crawlee-cheerio/src/main.js
+++ b/templates/js-crawlee-cheerio/src/main.js
@@ -1,3 +1,5 @@
+import { setTimeout } from 'node:timers/promises';
+
 // Crawlee - web scraping and browser automation library (Read more at https://crawlee.dev)
 import { CheerioCrawler, Dataset } from '@crawlee/cheerio';
 // Apify SDK - toolkit for building Apify Actors (Read more at https://docs.apify.com/sdk/js/)
@@ -12,7 +14,7 @@ Actor.on('aborting', async () => {
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 

--- a/templates/js-crawlee-playwright-camoufox/AGENTS.md
+++ b/templates/js-crawlee-playwright-camoufox/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```javascript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/js-crawlee-playwright-chrome/AGENTS.md
+++ b/templates/js-crawlee-playwright-chrome/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```javascript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/js-crawlee-puppeteer-chrome/AGENTS.md
+++ b/templates/js-crawlee-puppeteer-chrome/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```javascript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/js-cypress/AGENTS.md
+++ b/templates/js-cypress/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```javascript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/js-empty/AGENTS.md
+++ b/templates/js-empty/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```javascript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/js-langchain/AGENTS.md
+++ b/templates/js-langchain/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```javascript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/js-langgraph-agent/AGENTS.md
+++ b/templates/js-langgraph-agent/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```javascript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/js-standby/AGENTS.md
+++ b/templates/js-standby/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```javascript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/js-start/AGENTS.md
+++ b/templates/js-start/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```javascript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/ts-beeai-agent/AGENTS.md
+++ b/templates/ts-beeai-agent/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```typescript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/ts-bootstrap-cheerio-crawler/AGENTS.md
+++ b/templates/ts-bootstrap-cheerio-crawler/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```typescript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/ts-crawlee-cheerio/AGENTS.md
+++ b/templates/ts-crawlee-cheerio/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```typescript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/ts-crawlee-cheerio/src/main.ts
+++ b/templates/ts-crawlee-cheerio/src/main.ts
@@ -1,3 +1,5 @@
+import { setTimeout } from 'node:timers/promises';
+
 // Crawlee - web scraping and browser automation library (Read more at https://crawlee.dev)
 import { CheerioCrawler, Dataset } from '@crawlee/cheerio';
 // Apify SDK - toolkit for building Apify Actors (Read more at https://docs.apify.com/sdk/js/)
@@ -22,7 +24,7 @@ Actor.on('aborting', async () => {
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 

--- a/templates/ts-crawlee-playwright-camoufox/AGENTS.md
+++ b/templates/ts-crawlee-playwright-camoufox/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```typescript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/ts-crawlee-playwright-chrome/AGENTS.md
+++ b/templates/ts-crawlee-playwright-chrome/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```typescript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/ts-crawlee-puppeteer-chrome/AGENTS.md
+++ b/templates/ts-crawlee-puppeteer-chrome/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```typescript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/ts-empty/AGENTS.md
+++ b/templates/ts-empty/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```typescript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/ts-mastraai/AGENTS.md
+++ b/templates/ts-mastraai/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```typescript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/ts-mcp-empty/AGENTS.md
+++ b/templates/ts-mcp-empty/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```typescript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/ts-mcp-proxy/AGENTS.md
+++ b/templates/ts-mcp-proxy/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```typescript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/ts-playwright-test-runner/AGENTS.md
+++ b/templates/ts-playwright-test-runner/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```typescript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/ts-standby/AGENTS.md
+++ b/templates/ts-standby/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```typescript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/ts-start-bun/AGENTS.md
+++ b/templates/ts-start-bun/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```typescript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```

--- a/templates/ts-start/AGENTS.md
+++ b/templates/ts-start/AGENTS.md
@@ -80,12 +80,14 @@ The Apify log package provides the following methods for logging:
 Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
 
 ```typescript
+import { setTimeout } from 'node:timers/promises';
+
 Actor.on('aborting', async () => {
     // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
     // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
     // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
     // This is a temporary workaround until SDK implements proper state persistence in the aborting event
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await setTimeout(1000);
     await Actor.exit();
 });
 ```


### PR DESCRIPTION
## Summary
- Replace manual Promise wrapper around `setTimeout` with `await setTimeout(1000)` from `node:timers/promises`
- Fixes `no-promise-executor-return` ESLint rule violation in `js-crawlee-cheerio` and `ts-crawlee-cheerio` templates

## Test plan
- [x] Lint passes locally for both templates
- [x] TypeScript build passes
- [ ] CI should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)