### PR TITLE
fix: downgrade python-crewai to Python 3.13

### DIFF
--- a/templates/python-crewai/Dockerfile
+++ b/templates/python-crewai/Dockerfile
@@ -1,8 +1,8 @@
 # First, specify the base Docker image.
 # You can see the Docker images from Apify at https://hub.docker.com/r/apify/.
 # You can also use any other image from Docker Hub.
-# We are using Python 3.12 because 3.13 required compilation of the packages for the CrewAI setup.
-FROM apify/actor-python:3.14
+# We are using Python 3.13 because onnxruntime (a crewai dependency) doesn't have Python 3.14 wheels yet.
+FROM apify/actor-python:3.13
 
 # Second, copy just requirements.txt into the Actor image,
 # since it should be the only file that affects the dependency installation in the next step,


### PR DESCRIPTION
## Summary
- Downgrade `python-crewai` template from Python 3.14 to 3.13
- `onnxruntime` (a crewai dependency) doesn't have Python 3.14 wheels yet, causing Docker builds to fail

Fixes the CI failure: https://github.com/apify/actor-templates/actions/runs/21401435306/job/61613312204

## Test plan
- [ ] CI Docker build passes for `python-crewai` template

🤖 Generated with [Claude Code](https://claude.com/claude-code)