### PR TITLE
chore: Update ts-beeai-agent template to use beeai-framework

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,17 @@
             "groupSlug": "all-non-major",
             "automerge": true,
             "automergeType": "branch"
+        },
+        {
+            "description": "Disable updates for ts-beeai-agent packages with strict version constraints",
+            "matchFileNames": ["templates/ts-beeai-agent/**"],
+            "matchPackageNames": [
+                "beeai-framework",
+                "@ai-sdk/openai",
+                "@langchain/openai",
+                "@langchain/community"
+            ],
+            "enabled": false
         }
     ],
     "schedule": ["every weekday"],

--- a/templates/ts-beeai-agent/package.json
+++ b/templates/ts-beeai-agent/package.json
@@ -7,23 +7,24 @@
         "node": ">=18.0.0"
     },
     "dependencies": {
-        "@ai-sdk/openai": "^1.1.12",
-        "@langchain/openai": "^0.6.0",
-        "apify": "^3.5.2",
-        "bee-agent-framework": "^0.1.2",
+        "@ai-sdk/openai": "^1.3.24",
+        "@langchain/community": "0.2.31",
+        "@langchain/openai": "0.3.16",
+        "apify": "^3.5.3",
+        "beeai-framework": "0.1.20",
         "zod": "^3.25.67"
     },
     "devDependencies": {
-        "@apify/eslint-config": "^1.0.0",
+        "@apify/eslint-config": "^1.1.0",
         "@apify/tsconfig": "^0.1.1",
         "@types/node": "^22.15.32",
-        "eslint": "^9.29.0",
-        "eslint-config-prettier": "^10.1.5",
-        "globals": "^17.0.0",
-        "prettier": "^3.5.3",
-        "tsx": "^4.20.3",
+        "eslint": "^9.39.2",
+        "eslint-config-prettier": "^10.1.8",
+        "globals": "^17.2.0",
+        "prettier": "^3.8.1",
+        "tsx": "^4.21.0",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.34.1"
+        "typescript-eslint": "^8.54.0"
     },
     "scripts": {
         "start": "npm run start:dev",

--- a/templates/ts-beeai-agent/src/main.ts
+++ b/templates/ts-beeai-agent/src/main.ts
@@ -1,9 +1,9 @@
 import { ChatOpenAI } from '@langchain/openai';
 import { Actor, log } from 'apify';
-import { LangChainChatModel } from 'bee-agent-framework/adapters/langchain/backend/chat';
-import { OpenAIChatModel } from 'bee-agent-framework/adapters/openai/backend/chat';
-import { BeeAgent } from 'bee-agent-framework/agents/bee/agent';
-import { UnconstrainedMemory } from 'bee-agent-framework/memory/unconstrainedMemory';
+import { LangChainChatModel } from 'beeai-framework/adapters/langchain/backend/chat';
+import { OpenAIChatModel } from 'beeai-framework/adapters/openai/backend/chat';
+import { ReActAgent } from 'beeai-framework/agents/react/agent';
+import { UnconstrainedMemory } from 'beeai-framework/memory/unconstrainedMemory';
 import { z } from 'zod';
 
 import { StructuredOutputGenerator } from './structured_response_generator.js';
@@ -46,9 +46,9 @@ if (!query) {
 /**
  * Actor code
  */
-// Create a ReAct agent that can use tools.
-// See https://i-am-bee.github.io/bee-agent-framework/#/agents?id=bee-agent
-// In order to use PPE, the LangChain adapter must be used
+// Create an agent that can use tools.
+// See https://i-am-bee.github.io/beeai-framework/#/agents?id=react-agent
+// To use PPE, the LangChain adapter must be used
 // otherwise, the token usage is not tracked.
 log.debug(`Using model: ${modelName}`);
 const llm = new LangChainChatModel(new ChatOpenAI({ model: modelName }));
@@ -56,7 +56,7 @@ const llm = new LangChainChatModel(new ChatOpenAI({ model: modelName }));
 // for some reason.
 // Create a separate LLM for structured output generation.
 const llmStructured = new OpenAIChatModel(modelName);
-const agent = new BeeAgent({
+const agent = new ReActAgent({
     llm,
     memory: new UnconstrainedMemory(),
     tools: [new CalculatorSumTool(), new InstagramScrapeTool()],

--- a/templates/ts-beeai-agent/src/structured_response_generator.ts
+++ b/templates/ts-beeai-agent/src/structured_response_generator.ts
@@ -1,5 +1,5 @@
-import type { OpenAIChatModel } from 'bee-agent-framework/adapters/openai/backend/chat';
-import { Message } from 'bee-agent-framework/backend/message';
+import type { OpenAIChatModel } from 'beeai-framework/adapters/openai/backend/chat';
+import { Message } from 'beeai-framework/backend/message';
 import type { ZodSchema } from 'zod';
 
 // Tool message interface

--- a/templates/ts-beeai-agent/src/tools/calculator.ts
+++ b/templates/ts-beeai-agent/src/tools/calculator.ts
@@ -1,7 +1,7 @@
-import { Emitter } from 'bee-agent-framework/emitter/emitter';
-import type { AnyToolSchemaLike } from 'bee-agent-framework/internals/helpers/schema';
-import type { ToolEmitter, ToolInput } from 'bee-agent-framework/tools/base';
-import { JSONToolOutput, Tool, ToolInputValidationError } from 'bee-agent-framework/tools/base';
+import { Emitter } from 'beeai-framework/emitter/emitter';
+import type { AnyToolSchemaLike } from 'beeai-framework/internals/helpers/schema';
+import type { ToolEmitter, ToolInput } from 'beeai-framework/tools/base';
+import { JSONToolOutput, Tool, ToolInputValidationError } from 'beeai-framework/tools/base';
 import { z } from 'zod';
 
 interface CalculatorSumToolOutput {

--- a/templates/ts-beeai-agent/src/tools/instagram.ts
+++ b/templates/ts-beeai-agent/src/tools/instagram.ts
@@ -1,8 +1,8 @@
 import { ApifyClient, log } from 'apify';
-import { Emitter } from 'bee-agent-framework/emitter/emitter';
-import type { AnyToolSchemaLike } from 'bee-agent-framework/internals/helpers/schema';
-import type { ToolEmitter, ToolInput } from 'bee-agent-framework/tools/base';
-import { JSONToolOutput, Tool } from 'bee-agent-framework/tools/base';
+import { Emitter } from 'beeai-framework/emitter/emitter';
+import type { AnyToolSchemaLike } from 'beeai-framework/internals/helpers/schema';
+import type { ToolEmitter, ToolInput } from 'beeai-framework/tools/base';
+import { JSONToolOutput, Tool } from 'beeai-framework/tools/base';
 import { z } from 'zod';
 
 export interface InstagramPost {


### PR DESCRIPTION
  Update ts-beeai-agent template dependencies

  - Migrate from deprecated bee-agent-framework to beeai-framework@0.1.20
  - Update @langchain/openai to 0.3.16 and add @langchain/community@0.2.31
  - Update @ai-sdk/openai to ^1.3.24
  - Rename BeeAgent → ReActAgent in source files
  - Update dev dependencies (eslint, prettier, tsx, etc.)


  ⚠️ Add Renovate rule to disable updates for langchain etc. BeeAI framework depends on langchain < 1 and Renovate might constantly complain.  Yeah, this might also mean that we might miss updating it.

