### PR TITLE
feat: Add CLAUDE.md symlinks to AGENTS.md in all templates

### DIFF
--- a/scripts/copy-agents-md-to-templates.mts
+++ b/scripts/copy-agents-md-to-templates.mts
@@ -1,4 +1,4 @@
-import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { readdir, readFile, writeFile, symlink, unlink, lstat } from 'node:fs/promises';
 
 const baseDir = new URL('../agent-bases/', import.meta.url);
 const templatesDir = new URL('../templates/', import.meta.url);
@@ -24,6 +24,16 @@ for (const templateId of templateDirectoryElements) {
 
     if (templateFile) {
         await writeFile(new URL(`./${templateId}/AGENTS.md`, templatesDir), templateFile.content, 'utf-8');
+
+        // Create CLAUDE.md as a symlink to AGENTS.md
+        const claudeMdUrl = new URL(`./${templateId}/CLAUDE.md`, templatesDir);
+        try {
+            await lstat(claudeMdUrl);
+            await unlink(claudeMdUrl);
+        } catch {
+            // File doesn't exist, nothing to remove
+        }
+        await symlink('AGENTS.md', claudeMdUrl);
     }
 }
 

--- a/templates/js-bootstrap-cheerio-crawler/CLAUDE.md
+++ b/templates/js-bootstrap-cheerio-crawler/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/js-crawlee-cheerio/CLAUDE.md
+++ b/templates/js-crawlee-cheerio/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/js-crawlee-playwright-camoufox/CLAUDE.md
+++ b/templates/js-crawlee-playwright-camoufox/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/js-crawlee-playwright-chrome/CLAUDE.md
+++ b/templates/js-crawlee-playwright-chrome/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/js-crawlee-puppeteer-chrome/CLAUDE.md
+++ b/templates/js-crawlee-puppeteer-chrome/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/js-cypress/CLAUDE.md
+++ b/templates/js-cypress/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/js-empty/CLAUDE.md
+++ b/templates/js-empty/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/js-langchain/CLAUDE.md
+++ b/templates/js-langchain/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/js-langgraph-agent/CLAUDE.md
+++ b/templates/js-langgraph-agent/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/js-standby/CLAUDE.md
+++ b/templates/js-standby/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/js-start/CLAUDE.md
+++ b/templates/js-start/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-beautifulsoup/CLAUDE.md
+++ b/templates/python-beautifulsoup/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-crawlee-beautifulsoup/CLAUDE.md
+++ b/templates/python-crawlee-beautifulsoup/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-crawlee-parsel/CLAUDE.md
+++ b/templates/python-crawlee-parsel/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-crawlee-playwright-camoufox/CLAUDE.md
+++ b/templates/python-crawlee-playwright-camoufox/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-crawlee-playwright/CLAUDE.md
+++ b/templates/python-crawlee-playwright/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-crewai/CLAUDE.md
+++ b/templates/python-crewai/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-empty/CLAUDE.md
+++ b/templates/python-empty/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-langgraph/CLAUDE.md
+++ b/templates/python-langgraph/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-llamaindex-agent/CLAUDE.md
+++ b/templates/python-llamaindex-agent/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-mcp-empty/CLAUDE.md
+++ b/templates/python-mcp-empty/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-mcp-proxy/CLAUDE.md
+++ b/templates/python-mcp-proxy/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-playwright/CLAUDE.md
+++ b/templates/python-playwright/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-pydanticai/CLAUDE.md
+++ b/templates/python-pydanticai/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-scrapy/CLAUDE.md
+++ b/templates/python-scrapy/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-selenium/CLAUDE.md
+++ b/templates/python-selenium/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-smolagents/CLAUDE.md
+++ b/templates/python-smolagents/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-standby/CLAUDE.md
+++ b/templates/python-standby/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/python-start/CLAUDE.md
+++ b/templates/python-start/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/ts-beeai-agent/CLAUDE.md
+++ b/templates/ts-beeai-agent/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/ts-bootstrap-cheerio-crawler/CLAUDE.md
+++ b/templates/ts-bootstrap-cheerio-crawler/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/ts-crawlee-cheerio/CLAUDE.md
+++ b/templates/ts-crawlee-cheerio/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/ts-crawlee-playwright-camoufox/CLAUDE.md
+++ b/templates/ts-crawlee-playwright-camoufox/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/ts-crawlee-playwright-chrome/CLAUDE.md
+++ b/templates/ts-crawlee-playwright-chrome/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/ts-crawlee-puppeteer-chrome/CLAUDE.md
+++ b/templates/ts-crawlee-puppeteer-chrome/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/ts-empty/CLAUDE.md
+++ b/templates/ts-empty/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/ts-mastraai/CLAUDE.md
+++ b/templates/ts-mastraai/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/ts-mcp-empty/CLAUDE.md
+++ b/templates/ts-mcp-empty/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/ts-mcp-proxy/CLAUDE.md
+++ b/templates/ts-mcp-proxy/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/ts-playwright-test-runner/CLAUDE.md
+++ b/templates/ts-playwright-test-runner/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/ts-standby/CLAUDE.md
+++ b/templates/ts-standby/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/ts-start-bun/CLAUDE.md
+++ b/templates/ts-start-bun/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/ts-start/CLAUDE.md
+++ b/templates/ts-start/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Updated `scripts/copy-agents-md-to-templates.mts` to create a `CLAUDE.md` symlink pointing to `AGENTS.md` in each template directory
- Each template now ships with both `AGENTS.md` (source of truth) and `CLAUDE.md` (symlink) for compatibility with Claude Code
- Symlink creation is idempotent — existing `CLAUDE.md` files are removed before recreating

🤖 Generated with [Claude Code](https://claude.com/claude-code)