### PR TITLE
chore: Skip package.json update if BASE_IMAGE does not include 'node'

### DIFF
--- a/scripts/actions/update-templates.mts
+++ b/scripts/actions/update-templates.mts
@@ -63,6 +63,10 @@ const puppeteerDependencies = ['puppeteer'];
 const playwrightDependencies = ['playwright', '@playwright/test'];
 
 async function updatePackageJson(filePath: URL) {
+    if (!BASE_IMAGE.includes('node')) {
+        return;
+    }
+
     const content = await readFile(filePath, 'utf-8');
 
     const packageJson = JSON.parse(content);


### PR DESCRIPTION
Add a check for BASE_IMAGE to skip updates if not using Node.