### PR TITLE
chore: Remove view param from output_schema.json

### DIFF
--- a/templates/js-crawlee-cheerio/.actor/output_schema.json
+++ b/templates/js-crawlee-cheerio/.actor/output_schema.json
@@ -1,11 +1,11 @@
 {
     "actorOutputSchemaVersion": 1,
-    "title": "Output schema of the files scraper",
+    "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/js-crawlee-playwright-camoufox/.actor/output_schema.json
+++ b/templates/js-crawlee-playwright-camoufox/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/js-crawlee-playwright-chrome/.actor/output_schema.json
+++ b/templates/js-crawlee-playwright-chrome/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/js-crawlee-puppeteer-chrome/.actor/output_schema.json
+++ b/templates/js-crawlee-puppeteer-chrome/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/js-cypress/.actor/output_schema.json
+++ b/templates/js-cypress/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         },
         "videos": {
             "type": "string",

--- a/templates/js-langgraph-agent/.actor/output_schema.json
+++ b/templates/js-langgraph-agent/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/js-start/.actor/output_schema.json
+++ b/templates/js-start/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/python-beautifulsoup/.actor/output_schema.json
+++ b/templates/python-beautifulsoup/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/python-crawlee-beautifulsoup/.actor/output_schema.json
+++ b/templates/python-crawlee-beautifulsoup/.actor/output_schema.json
@@ -1,11 +1,11 @@
 {
     "actorOutputSchemaVersion": 1,
-    "title": "Output schema of the files scraper",
+    "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/python-crawlee-parsel/.actor/output_schema.json
+++ b/templates/python-crawlee-parsel/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/python-crawlee-playwright-camoufox/.actor/output_schema.json
+++ b/templates/python-crawlee-playwright-camoufox/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/python-crawlee-playwright/.actor/output_schema.json
+++ b/templates/python-crawlee-playwright/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/python-crewai/.actor/output_schema.json
+++ b/templates/python-crewai/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/python-langgraph/.actor/output_schema.json
+++ b/templates/python-langgraph/.actor/output_schema.json
@@ -2,15 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
-        },
-        "responses": {
-            "type": "string",
-            "title": "Responses",
-            "template": "{{links.apiDefaultKeyValueStoreUrl}}/keys?collection=responses"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/python-llamaindex-agent/.actor/output_schema.json
+++ b/templates/python-llamaindex-agent/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/python-playwright/.actor/output_schema.json
+++ b/templates/python-playwright/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/python-pydanticai/.actor/output_schema.json
+++ b/templates/python-pydanticai/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/python-selenium/.actor/output_schema.json
+++ b/templates/python-selenium/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/python-smolagents/.actor/output_schema.json
+++ b/templates/python-smolagents/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/python-start/.actor/output_schema.json
+++ b/templates/python-start/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/ts-beeai-agent/.actor/output_schema.json
+++ b/templates/ts-beeai-agent/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/ts-crawlee-cheerio/.actor/output_schema.json
+++ b/templates/ts-crawlee-cheerio/.actor/output_schema.json
@@ -1,11 +1,11 @@
 {
     "actorOutputSchemaVersion": 1,
-    "title": "Output schema of the files scraper",
+    "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/ts-crawlee-playwright-camoufox/.actor/output_schema.json
+++ b/templates/ts-crawlee-playwright-camoufox/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/ts-crawlee-playwright-chrome/.actor/output_schema.json
+++ b/templates/ts-crawlee-playwright-chrome/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/ts-crawlee-puppeteer-chrome/.actor/output_schema.json
+++ b/templates/ts-crawlee-puppeteer-chrome/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/ts-mastraai/.actor/output_schema.json
+++ b/templates/ts-mastraai/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/ts-playwright-test-runner/.actor/output_schema.json
+++ b/templates/ts-playwright-test-runner/.actor/output_schema.json
@@ -2,15 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
-        },
-        "report": {
-            "type": "string",
-            "title": "HTML Report",
-            "template": "{{links.apiDefaultKeyValueStoreUrl}}/records/report"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/ts-playwright-test-runner/.actor/output_schema.json
+++ b/templates/ts-playwright-test-runner/.actor/output_schema.json
@@ -6,6 +6,11 @@
             "type": "string",
             "title": "Results",
             "template": "{{links.apiDefaultDatasetUrl}}/items"
+        },
+        "report": {
+            "type": "string",
+            "title": "HTML Report",
+            "template": "{{links.apiDefaultKeyValueStoreUrl}}/records/report"
         }
     }
 }

--- a/templates/ts-start-bun/.actor/output_schema.json
+++ b/templates/ts-start-bun/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }

--- a/templates/ts-start/.actor/output_schema.json
+++ b/templates/ts-start/.actor/output_schema.json
@@ -2,10 +2,10 @@
     "actorOutputSchemaVersion": 1,
     "title": "Output schema",
     "properties": {
-        "overview": {
+        "results": {
             "type": "string",
-            "title": "Overview",
-            "template": "{{links.apiDefaultDatasetUrl}}/items?view=overview"
+            "title": "Results",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Removed `?view=overview` query parameter from the `template` URL in all `output_schema.json` files across 29 templates
- Renamed the output property from `overview`/`Overview` to `results`/`Results` to match the simplified default
- The simple `/items` endpoint is sufficient for most Actors that store data in the default dataset