### PR TITLE
refactor: Replace CLAUDE.md symlinks with @AGENTS.md import

### DIFF
--- a/scripts/copy-agents-md-to-templates.mts
+++ b/scripts/copy-agents-md-to-templates.mts
@@ -1,4 +1,4 @@
-import { readdir, readFile, writeFile, symlink, unlink, lstat } from 'node:fs/promises';
+import { readdir, readFile, writeFile, unlink, lstat } from 'node:fs/promises';
 
 const baseDir = new URL('../agent-bases/', import.meta.url);
 const templatesDir = new URL('../templates/', import.meta.url);
@@ -23,9 +23,9 @@ for (const templateId of templateDirectoryElements) {
     const templateFile = baseFiles.find((file) => file.templateMatches(templateId));
 
     if (templateFile) {
-        await writeFile(new URL(`./${templateId}/AGENTS.md`, templatesDir), templateFile.content, 'utf-8');
-
-        // Create CLAUDE.md as a symlink to AGENTS.md
+        // Remove any pre-existing CLAUDE.md first. Older versions of this script
+        // created it as a symlink to AGENTS.md, so writing through the path would
+        // follow the link and clobber AGENTS.md.
         const claudeMdUrl = new URL(`./${templateId}/CLAUDE.md`, templatesDir);
         try {
             await lstat(claudeMdUrl);
@@ -33,7 +33,9 @@ for (const templateId of templateDirectoryElements) {
         } catch {
             // File doesn't exist, nothing to remove
         }
-        await symlink('AGENTS.md', claudeMdUrl);
+
+        await writeFile(new URL(`./${templateId}/AGENTS.md`, templatesDir), templateFile.content, 'utf-8');
+        await writeFile(claudeMdUrl, '@AGENTS.md\n', 'utf-8');
     }
 }
 

--- a/templates/js-bootstrap-cheerio-crawler/CLAUDE.md
+++ b/templates/js-bootstrap-cheerio-crawler/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/js-crawlee-cheerio/CLAUDE.md
+++ b/templates/js-crawlee-cheerio/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/js-crawlee-playwright-camoufox/CLAUDE.md
+++ b/templates/js-crawlee-playwright-camoufox/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/js-crawlee-playwright-chrome/CLAUDE.md
+++ b/templates/js-crawlee-playwright-chrome/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/js-crawlee-puppeteer-chrome/CLAUDE.md
+++ b/templates/js-crawlee-puppeteer-chrome/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/js-cypress/CLAUDE.md
+++ b/templates/js-cypress/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/js-empty/CLAUDE.md
+++ b/templates/js-empty/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/js-langchain/CLAUDE.md
+++ b/templates/js-langchain/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/js-langgraph-agent/CLAUDE.md
+++ b/templates/js-langgraph-agent/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/js-standby/CLAUDE.md
+++ b/templates/js-standby/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/js-start/CLAUDE.md
+++ b/templates/js-start/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-beautifulsoup/CLAUDE.md
+++ b/templates/python-beautifulsoup/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-crawlee-beautifulsoup/CLAUDE.md
+++ b/templates/python-crawlee-beautifulsoup/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-crawlee-parsel/CLAUDE.md
+++ b/templates/python-crawlee-parsel/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-crawlee-playwright-camoufox/CLAUDE.md
+++ b/templates/python-crawlee-playwright-camoufox/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-crawlee-playwright/CLAUDE.md
+++ b/templates/python-crawlee-playwright/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-crewai/CLAUDE.md
+++ b/templates/python-crewai/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-empty/CLAUDE.md
+++ b/templates/python-empty/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-langgraph/CLAUDE.md
+++ b/templates/python-langgraph/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-llamaindex-agent/CLAUDE.md
+++ b/templates/python-llamaindex-agent/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-mcp-empty/CLAUDE.md
+++ b/templates/python-mcp-empty/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-mcp-proxy/CLAUDE.md
+++ b/templates/python-mcp-proxy/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-playwright/CLAUDE.md
+++ b/templates/python-playwright/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-pydanticai/CLAUDE.md
+++ b/templates/python-pydanticai/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-scrapy/CLAUDE.md
+++ b/templates/python-scrapy/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-selenium/CLAUDE.md
+++ b/templates/python-selenium/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-smolagents/CLAUDE.md
+++ b/templates/python-smolagents/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-standby/CLAUDE.md
+++ b/templates/python-standby/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/python-start/CLAUDE.md
+++ b/templates/python-start/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/ts-beeai-agent/CLAUDE.md
+++ b/templates/ts-beeai-agent/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/ts-bootstrap-cheerio-crawler/CLAUDE.md
+++ b/templates/ts-bootstrap-cheerio-crawler/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/ts-crawlee-cheerio/CLAUDE.md
+++ b/templates/ts-crawlee-cheerio/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/ts-crawlee-playwright-camoufox/CLAUDE.md
+++ b/templates/ts-crawlee-playwright-camoufox/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/ts-crawlee-playwright-chrome/CLAUDE.md
+++ b/templates/ts-crawlee-playwright-chrome/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/ts-crawlee-puppeteer-chrome/CLAUDE.md
+++ b/templates/ts-crawlee-puppeteer-chrome/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/ts-empty/CLAUDE.md
+++ b/templates/ts-empty/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/ts-mastraai/CLAUDE.md
+++ b/templates/ts-mastraai/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/ts-mcp-empty/CLAUDE.md
+++ b/templates/ts-mcp-empty/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/ts-mcp-proxy/CLAUDE.md
+++ b/templates/ts-mcp-proxy/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/ts-playwright-test-runner/CLAUDE.md
+++ b/templates/ts-playwright-test-runner/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/ts-standby/CLAUDE.md
+++ b/templates/ts-standby/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/ts-start-bun/CLAUDE.md
+++ b/templates/ts-start-bun/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/templates/ts-start/CLAUDE.md
+++ b/templates/ts-start/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
## Summary
- Each template's `CLAUDE.md` is now a one-line file containing `@AGENTS.md` instead of a symlink to `AGENTS.md`.
- Updates `scripts/copy-agents-md-to-templates.mts` to write the import line; the old symlink-creation logic is gone.
- Kept the pre-write `unlink` step so the script safely upgrades repos where `CLAUDE.md` is still a legacy symlink (writing through it would clobber `AGENTS.md`).

## Why
The symlink only existed in the source tree. The distribution pipeline in `src/build_templates.js` uses `globby` (follows symlinks) and `zip` without `-y`, so every published zip contained a duplicated ~25 KB `CLAUDE.md` file rather than a link. Symlinks in zip archives are also not portable to Windows.

`@AGENTS.md` is the approach Anthropic officially documents for keeping AGENTS.md and CLAUDE.md in sync without duplication — see https://code.claude.com/docs/en/memory#agents-md. Claude Code expands the `@` import into AGENTS.md's contents at launch. Result: single source of truth, zip-safe, cross-platform, 11 bytes per template instead of 25 KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)