### PR TITLE
fix(ts-templates): disable incremental builds

### DIFF
--- a/templates/ts-beeai-agent/tsconfig.json
+++ b/templates/ts-beeai-agent/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
+        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-beeai-agent/tsconfig.json
+++ b/templates/ts-beeai-agent/tsconfig.json
@@ -6,7 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
-        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+        "incremental": false,
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-bootstrap-cheerio-crawler/tsconfig.json
+++ b/templates/ts-bootstrap-cheerio-crawler/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
+        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-bootstrap-cheerio-crawler/tsconfig.json
+++ b/templates/ts-bootstrap-cheerio-crawler/tsconfig.json
@@ -6,7 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
-        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+        "incremental": false,
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-crawlee-cheerio/tsconfig.json
+++ b/templates/ts-crawlee-cheerio/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
+        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-crawlee-cheerio/tsconfig.json
+++ b/templates/ts-crawlee-cheerio/tsconfig.json
@@ -6,7 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
-        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+        "incremental": false,
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-crawlee-playwright-camoufox/tsconfig.json
+++ b/templates/ts-crawlee-playwright-camoufox/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
+        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-crawlee-playwright-camoufox/tsconfig.json
+++ b/templates/ts-crawlee-playwright-camoufox/tsconfig.json
@@ -6,7 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
-        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+        "incremental": false,
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-crawlee-playwright-chrome/tsconfig.json
+++ b/templates/ts-crawlee-playwright-chrome/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
+        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-crawlee-playwright-chrome/tsconfig.json
+++ b/templates/ts-crawlee-playwright-chrome/tsconfig.json
@@ -6,7 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
-        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+        "incremental": false,
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-crawlee-puppeteer-chrome/tsconfig.json
+++ b/templates/ts-crawlee-puppeteer-chrome/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
+        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-crawlee-puppeteer-chrome/tsconfig.json
+++ b/templates/ts-crawlee-puppeteer-chrome/tsconfig.json
@@ -6,7 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
-        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+        "incremental": false,
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-empty/tsconfig.json
+++ b/templates/ts-empty/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
+        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-empty/tsconfig.json
+++ b/templates/ts-empty/tsconfig.json
@@ -6,7 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
-        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+        "incremental": false,
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-mastraai/tsconfig.json
+++ b/templates/ts-mastraai/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
+        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-mastraai/tsconfig.json
+++ b/templates/ts-mastraai/tsconfig.json
@@ -6,7 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
-        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+        "incremental": false,
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-mcp-empty/tsconfig.json
+++ b/templates/ts-mcp-empty/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
+        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-mcp-empty/tsconfig.json
+++ b/templates/ts-mcp-empty/tsconfig.json
@@ -6,7 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
-        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+        "incremental": false,
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-mcp-proxy/tsconfig.json
+++ b/templates/ts-mcp-proxy/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
+        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-mcp-proxy/tsconfig.json
+++ b/templates/ts-mcp-proxy/tsconfig.json
@@ -6,7 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
-        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+        "incremental": false,
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-playwright-test-runner/tsconfig.json
+++ b/templates/ts-playwright-test-runner/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "ESNext",
         "outDir": "dist",
         "rootDir": ".",
+        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-playwright-test-runner/tsconfig.json
+++ b/templates/ts-playwright-test-runner/tsconfig.json
@@ -6,7 +6,7 @@
         "target": "ESNext",
         "outDir": "dist",
         "rootDir": ".",
-        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+        "incremental": false,
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-standby/tsconfig.json
+++ b/templates/ts-standby/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
+        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-standby/tsconfig.json
+++ b/templates/ts-standby/tsconfig.json
@@ -6,7 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
-        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+        "incremental": false,
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-start-bun/tsconfig.json
+++ b/templates/ts-start-bun/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
+        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-start-bun/tsconfig.json
+++ b/templates/ts-start-bun/tsconfig.json
@@ -6,7 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
-        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+        "incremental": false,
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-start/tsconfig.json
+++ b/templates/ts-start/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
+        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/templates/ts-start/tsconfig.json
+++ b/templates/ts-start/tsconfig.json
@@ -6,7 +6,7 @@
         "target": "ES2022",
         "outDir": "dist",
         "rootDir": "./src",
-        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+        "incremental": false,
         "noUnusedLocals": false,
         "skipLibCheck": true,
         "lib": ["DOM"]

--- a/test/tsconfig.test.js
+++ b/test/tsconfig.test.js
@@ -11,14 +11,14 @@ const tsTemplateIds = fs
     .map((entry) => entry.name);
 
 describe('ts-template tsconfig', () => {
-    // Regression for #754: @apify/tsconfig sets incremental:true; without
-    // tsBuildInfoFile inside outDir the buildinfo lands at the repo root and
-    // survives `rm -rf dist`, tricking tsc into skipping the next emit.
-    test.each(tsTemplateIds)('%s places tsBuildInfoFile inside outDir', (templateId) => {
+    // Regression for #754: @apify/tsconfig sets incremental:true, which writes
+    // tsconfig.tsbuildinfo at the project root. After `rm -rf dist` it survives
+    // and tricks tsc into skipping the next emit, so `apify push` ships an
+    // empty actor. Templates opt out of incremental builds entirely.
+    test.each(tsTemplateIds)('%s disables incremental builds', (templateId) => {
         const tsconfigPath = path.join(TEMPLATES_DIRECTORY, templateId, 'tsconfig.json');
         const tsconfig = JSON5.parse(fs.readFileSync(tsconfigPath, 'utf8'));
 
-        const { outDir, tsBuildInfoFile } = tsconfig.compilerOptions;
-        expect(tsBuildInfoFile).toBe(`${outDir}/tsconfig.tsbuildinfo`);
+        expect(tsconfig.compilerOptions.incremental).toBe(false);
     });
 });

--- a/test/tsconfig.test.js
+++ b/test/tsconfig.test.js
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import JSON5 from 'json5';
+
+const TEMPLATES_DIRECTORY = path.join(import.meta.dirname, '../templates');
+
+const tsTemplateIds = fs
+    .readdirSync(TEMPLATES_DIRECTORY, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith('ts-'))
+    .map((entry) => entry.name);
+
+describe('ts-template tsconfig', () => {
+    // Regression for #754: @apify/tsconfig sets incremental:true; without
+    // tsBuildInfoFile inside outDir the buildinfo lands at the repo root and
+    // survives `rm -rf dist`, tricking tsc into skipping the next emit.
+    test.each(tsTemplateIds)('%s places tsBuildInfoFile inside outDir', (templateId) => {
+        const tsconfigPath = path.join(TEMPLATES_DIRECTORY, templateId, 'tsconfig.json');
+        const tsconfig = JSON5.parse(fs.readFileSync(tsconfigPath, 'utf8'));
+
+        const { outDir, tsBuildInfoFile } = tsconfig.compilerOptions;
+        expect(tsBuildInfoFile).toBe(`${outDir}/tsconfig.tsbuildinfo`);
+    });
+});


### PR DESCRIPTION
## Summary

- All `templates/ts-*/tsconfig.json` files now set `"incremental": false` so `tsc` no longer writes a `tsconfig.tsbuildinfo` file at all.
- Adds `test/tsconfig.test.js` as a config-shape regression guard for all 14 TypeScript templates.

## Why

`@apify/tsconfig` sets `incremental: true`. Without an explicit `tsBuildInfoFile`, `tsc` writes `tsconfig.tsbuildinfo` next to `tsconfig.json` (the project root). After a user runs `rm -rf dist`, the buildinfo at the root survives and convinces `tsc` that nothing changed, so the next `npm run build` emits nothing — breaking `apify push` (uploads with no `dist/`) and `node dist/main.js`.

The first version of this PR fixed it by moving the buildinfo into `outDir`, but that ships the buildinfo file inside the actor. Templates are built once on `apify push`, so the speedup from incremental compilation is negligible — disabling it removes the buildinfo file entirely and eliminates the class of bug rather than papering over one symptom.

Reproduction (from #754):
```
apify create test --template=ts-crawlee-cheerio
cd test && npm install && npm run build
rm -rf dist && npm run build  # before fix: no dist/ generated
```

Closes #754

## Test plan

- [x] Reproduce the bug on `ts-crawlee-cheerio` before the fix (no `dist/` after second build)
- [x] Verify the fix on `ts-crawlee-cheerio`: `npm run build`, `rm -rf dist`, `npm run build` → `dist/` is regenerated and no `tsconfig.tsbuildinfo` is created (in `dist/` or at the repo root)
- [x] `npm run test-without-templates` passes (17 tests, includes the new 14)
- [x] `npm run lint` passes
- [ ] CI runs the heavy `test-templates` job against all TS templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)