### PR TITLE
ci: catch formatting issues at PR time

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -61,6 +61,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Check formatting
+        run: npm run format:check
+
       - name: Test building templates
         run: npm run build
 

--- a/agent-bases/js.AGENTS.md
+++ b/agent-bases/js.AGENTS.md
@@ -656,12 +656,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/agent-bases/python.AGENTS.md
+++ b/agent-bases/python.AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/agent-bases/ts.AGENTS.md
+++ b/agent-bases/ts.AGENTS.md
@@ -659,12 +659,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/renovate.json
+++ b/renovate.json
@@ -26,12 +26,7 @@
         {
             "description": "Disable updates for ts-beeai-agent packages with strict version constraints",
             "matchFileNames": ["templates/ts-beeai-agent/**"],
-            "matchPackageNames": [
-                "beeai-framework",
-                "@ai-sdk/openai",
-                "@langchain/openai",
-                "@langchain/community"
-            ],
+            "matchPackageNames": ["beeai-framework", "@ai-sdk/openai", "@langchain/openai", "@langchain/community"],
             "enabled": false
         }
     ],

--- a/templates/js-bootstrap-cheerio-crawler/AGENTS.md
+++ b/templates/js-bootstrap-cheerio-crawler/AGENTS.md
@@ -656,12 +656,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/js-crawlee-cheerio/AGENTS.md
+++ b/templates/js-crawlee-cheerio/AGENTS.md
@@ -656,12 +656,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/js-crawlee-playwright-camoufox/AGENTS.md
+++ b/templates/js-crawlee-playwright-camoufox/AGENTS.md
@@ -656,12 +656,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/js-crawlee-playwright-chrome/AGENTS.md
+++ b/templates/js-crawlee-playwright-chrome/AGENTS.md
@@ -656,12 +656,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/js-crawlee-puppeteer-chrome/AGENTS.md
+++ b/templates/js-crawlee-puppeteer-chrome/AGENTS.md
@@ -656,12 +656,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/js-cypress/AGENTS.md
+++ b/templates/js-cypress/AGENTS.md
@@ -656,12 +656,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/js-empty/AGENTS.md
+++ b/templates/js-empty/AGENTS.md
@@ -656,12 +656,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/js-langchain/AGENTS.md
+++ b/templates/js-langchain/AGENTS.md
@@ -656,12 +656,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/js-langgraph-agent/AGENTS.md
+++ b/templates/js-langgraph-agent/AGENTS.md
@@ -656,12 +656,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/js-standby/AGENTS.md
+++ b/templates/js-standby/AGENTS.md
@@ -656,12 +656,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/js-start/AGENTS.md
+++ b/templates/js-start/AGENTS.md
@@ -656,12 +656,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-beautifulsoup/AGENTS.md
+++ b/templates/python-beautifulsoup/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-crawlee-beautifulsoup/AGENTS.md
+++ b/templates/python-crawlee-beautifulsoup/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-crawlee-parsel/AGENTS.md
+++ b/templates/python-crawlee-parsel/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-crawlee-playwright-camoufox/AGENTS.md
+++ b/templates/python-crawlee-playwright-camoufox/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-crawlee-playwright/AGENTS.md
+++ b/templates/python-crawlee-playwright/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-crewai/AGENTS.md
+++ b/templates/python-crewai/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-empty/AGENTS.md
+++ b/templates/python-empty/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-langgraph/AGENTS.md
+++ b/templates/python-langgraph/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-llamaindex-agent/AGENTS.md
+++ b/templates/python-llamaindex-agent/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-mcp-empty/AGENTS.md
+++ b/templates/python-mcp-empty/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-mcp-proxy/AGENTS.md
+++ b/templates/python-mcp-proxy/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-playwright/AGENTS.md
+++ b/templates/python-playwright/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-pydanticai/AGENTS.md
+++ b/templates/python-pydanticai/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-scrapy/AGENTS.md
+++ b/templates/python-scrapy/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-selenium/AGENTS.md
+++ b/templates/python-selenium/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-smolagents/AGENTS.md
+++ b/templates/python-smolagents/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-standby/AGENTS.md
+++ b/templates/python-standby/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/python-start/AGENTS.md
+++ b/templates/python-start/AGENTS.md
@@ -669,12 +669,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/ts-beeai-agent/AGENTS.md
+++ b/templates/ts-beeai-agent/AGENTS.md
@@ -659,12 +659,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/ts-bootstrap-cheerio-crawler/AGENTS.md
+++ b/templates/ts-bootstrap-cheerio-crawler/AGENTS.md
@@ -659,12 +659,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/ts-crawlee-cheerio/AGENTS.md
+++ b/templates/ts-crawlee-cheerio/AGENTS.md
@@ -659,12 +659,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/ts-crawlee-playwright-camoufox/AGENTS.md
+++ b/templates/ts-crawlee-playwright-camoufox/AGENTS.md
@@ -659,12 +659,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/ts-crawlee-playwright-chrome/AGENTS.md
+++ b/templates/ts-crawlee-playwright-chrome/AGENTS.md
@@ -659,12 +659,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/ts-crawlee-puppeteer-chrome/AGENTS.md
+++ b/templates/ts-crawlee-puppeteer-chrome/AGENTS.md
@@ -659,12 +659,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/ts-empty/AGENTS.md
+++ b/templates/ts-empty/AGENTS.md
@@ -659,12 +659,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/ts-mastraai/AGENTS.md
+++ b/templates/ts-mastraai/AGENTS.md
@@ -659,12 +659,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/ts-mcp-empty/AGENTS.md
+++ b/templates/ts-mcp-empty/AGENTS.md
@@ -659,12 +659,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/ts-mcp-proxy/AGENTS.md
+++ b/templates/ts-mcp-proxy/AGENTS.md
@@ -659,12 +659,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/ts-playwright-test-runner/AGENTS.md
+++ b/templates/ts-playwright-test-runner/AGENTS.md
@@ -659,12 +659,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/ts-standby/AGENTS.md
+++ b/templates/ts-standby/AGENTS.md
@@ -659,12 +659,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/ts-start-bun/AGENTS.md
+++ b/templates/ts-start-bun/AGENTS.md
@@ -659,12 +659,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 

--- a/templates/ts-start/AGENTS.md
+++ b/templates/ts-start/AGENTS.md
@@ -659,12 +659,12 @@ Or add it manually to your MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"]
+        }
     }
-  }
 }
 ```
 


### PR DESCRIPTION
## Summary

Adds `prettier --check` to the lint/test workflow. Today, formatting drift in shared files (notably the `agent-bases/*.AGENTS.md` source-of-truth that gets fanned out into every template's `AGENTS.md`) only surfaces *after* merge, when the per-template e2e checks fire — see the post-merge comment on #766.

This PR adds the check **only**; the resulting CI failure is intentional and demonstrates the gap. A follow-up commit on the same branch will reformat the offending files so the check goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)