### PR TITLE
chore: auto-label new issues with t-dx

### DIFF
--- a/.github/workflows/update-new-issue.yaml
+++ b/.github/workflows/update-new-issue.yaml
@@ -1,0 +1,25 @@
+name: Update new issue
+
+on:
+    issues:
+        types:
+            - opened
+
+jobs:
+    label_issues:
+        name: Label issues
+        runs-on: ubuntu-latest
+        permissions:
+            issues: write
+
+        steps:
+            # Add the "t-dx" label to all new issues
+            - uses: actions/github-script@v8
+              with:
+                  script: |
+                      github.rest.issues.addLabels({
+                          issue_number: context.issue.number,
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          labels: ["t-dx"]
+                      })


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that auto-applies the `t-dx` label to every newly opened issue, matching the existing setup in [apify/apify-cli](https://github.com/apify/apify-cli/blob/master/.github/workflows/issue_labeling.yaml).

## Test plan
- [ ] Open a new issue and verify the `t-dx` label is applied automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)