### PR TITLE
chore: apply prettier formatting to update-new-issue workflow

### DIFF
--- a/.github/workflows/update-new-issue.yaml
+++ b/.github/workflows/update-new-issue.yaml
@@ -1,25 +1,25 @@
 name: Update new issue
 
 on:
-    issues:
-        types:
-            - opened
+  issues:
+    types:
+      - opened
 
 jobs:
-    label_issues:
-        name: Label issues
-        runs-on: ubuntu-latest
-        permissions:
-            issues: write
+  label_issues:
+    name: Label issues
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
 
-        steps:
-            # Add the "t-dx" label to all new issues
-            - uses: actions/github-script@v8
-              with:
-                  script: |
-                      github.rest.issues.addLabels({
-                          issue_number: context.issue.number,
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          labels: ["t-dx"]
-                      })
+    steps:
+      # Add the "t-dx" label to all new issues
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ["t-dx"]
+            })


### PR DESCRIPTION
## Summary
- Reformats `.github/workflows/update-new-issue.yaml` (added in #772) with prettier — the file was committed with the apify/actor-scraper indent style and is failing the repo's `format:check` ([failing run](https://github.com/apify/actor-templates/actions/runs/26027697462/job/76505237737)).

## Test plan
- [ ] `npm run format:check` passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)