### PR TITLE
feat: refine template manifesto with use case tags

### DIFF
--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -278,7 +278,7 @@
                 "timeoutSecs": 600
             },
             "showcaseFiles": ["my_actor/main.py", "my_actor/agent.py", "my_actor/tools.py", "my_actor/__main__.py"],
-            "useCases": ["AI", "WEB_SCRAPING"]
+            "useCases": ["AI"]
         },
         {
             "id": "python-pydanticai",
@@ -467,7 +467,7 @@
             },
             "skipOptionalDeps": true,
             "showcaseFiles": ["src/main.js", "src/routes.js"],
-            "useCases": ["STARTER", "WEB_SCRAPING"]
+            "useCases": ["WEB_SCRAPING"]
         },
         {
             "id": "ts-start",
@@ -651,7 +651,7 @@
                 "timeoutSecs": 3600
             },
             "showcaseFiles": ["src/main.js", "src/vector_index_cache.js"],
-            "useCases": ["AI", "WEB_SCRAPING"]
+            "useCases": ["AI"]
         },
         {
             "id": "js-langgraph-agent",

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -548,7 +548,7 @@
                 "timeoutSecs": 3600
             },
             "showcaseFiles": ["src/main.ts", "src/runCodegen.ts", "src/transform.ts"],
-            "useCases": ["AUTOMATION", "INTEGRATION"]
+            "useCases": ["AUTOMATION"]
         },
         {
             "id": "ts-empty",
@@ -766,7 +766,7 @@
             },
             "showcaseFiles": ["main.sh"],
             "skipTests": true,
-            "useCases": ["STARTER", "INTEGRATION", "AUTOMATION"]
+            "useCases": ["STARTER", "INTEGRATION"]
         }
     ]
 }

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,14 @@
 {
     "consoleReadmeSuffixUrl": "https://raw.githubusercontent.com/apify/actor-templates/master/templates/console_readme_suffix.md",
     "localReadmeSuffixUrl": "https://raw.githubusercontent.com/apify/actor-templates/master/templates/local_readme_suffix.md",
+    "_useCaseDescriptions": {
+        "_note": "Reference for what each value in a template's `useCases` array represents. Templates may carry multiple use cases; pick the tag(s) that reflect what the template actually IS, not what it could become.",
+        "STARTER": "Entry-level scaffold for a user's first Actor — language quickstarts, empty projects, standby starters, generic wrappers (e.g. cli-start).",
+        "WEB_SCRAPING": "Extracting structured data from websites — HTTP scrapers, browser scrapers, crawlers. The template's primary output is scraped data.",
+        "INTEGRATION": "Bridges Apify with external systems — Standby mode (serves HTTP), MCP servers (callable by AI clients), or templates that call out to external APIs, services, or CLIs.",
+        "AUTOMATION": "Performs actions rather than extracting data — test runners, browser automation (Playwright/Selenium/Cypress used for interaction), CLI orchestration.",
+        "AI": "LLM-powered agents, AI tool servers (MCP), and AI framework integration demos (LangChain, CrewAI, etc.)."
+    },
     "templates": [
         {
             "id": "python-crawlee-beautifulsoup",
@@ -8,7 +16,7 @@
             "label": "Crawlee + BeautifulSoup",
             "category": "python",
             "technologies": ["crawlee", "beautifulsoup"],
-            "description": "Crawl and scrape websites using Crawlee and BeautifulSoup. Start from a given start URLs, and store results to Apify dataset.",
+            "description": "Crawl and scrape websites using Crawlee and BeautifulSoup. Start from a URL and store results to your Apify dataset.",
             "messages": {
                 "postCreate": "To install additional Python packages, you need to activate the virtual environment in the \".venv\" folder in the actor directory."
             },
@@ -27,7 +35,7 @@
             "name": "python-empty",
             "label": "Empty Python project",
             "category": "python",
-            "description": "Empty template with basic structure for the Actor with Apify SDK that allows you to easily add your own functionality.",
+            "description": "Start with Apify SDK already set up, then build any features you need.",
             "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/python-empty.zip?raw=true",
             "defaultRunOptions": {
                 "build": "latest",
@@ -35,7 +43,7 @@
                 "timeoutSecs": 3600
             },
             "showcaseFiles": ["my_actor/main.py", "my_actor/__main__.py"],
-            "useCases": ["WEB_SCRAPING"]
+            "useCases": ["STARTER"]
         },
         {
             "id": "python-start",
@@ -93,7 +101,7 @@
                 "timeoutSecs": 3600
             },
             "showcaseFiles": ["my_actor/main.py", "my_actor/__main__.py"],
-            "useCases": ["WEB_SCRAPING"]
+            "useCases": ["WEB_SCRAPING", "AUTOMATION"]
         },
         {
             "id": "python-selenium",
@@ -112,14 +120,14 @@
                 "timeoutSecs": 3600
             },
             "showcaseFiles": ["my_actor/main.py", "my_actor/__main__.py"],
-            "useCases": ["WEB_SCRAPING"]
+            "useCases": ["WEB_SCRAPING", "AUTOMATION"]
         },
         {
             "id": "python-standby",
             "name": "python-standby",
             "label": "Standby Python project",
             "category": "python",
-            "description": "Template with basic structure for an Actor using Standby mode that allows you to easily add your own functionality.",
+            "description": "Start with a working Actor in Standby mode that stays ready in the background, then build any features you need.",
             "skipTests": true,
             "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/python-standby.zip?raw=true",
             "defaultRunOptions": {
@@ -128,7 +136,7 @@
                 "timeoutSecs": 3600
             },
             "showcaseFiles": ["my_actor/main.py", "my_actor/__main__.py"],
-            "useCases": ["STARTER"]
+            "useCases": ["STARTER", "INTEGRATION"]
         },
         {
             "id": "python-scrapy",
@@ -163,7 +171,7 @@
             "label": "Crawlee + Parsel",
             "category": "python",
             "technologies": ["crawlee", "parsel"],
-            "description": "Crawl and scrape websites using Crawlee and Parsel. Start from a given start URLs, and store results to Apify dataset.",
+            "description": "Crawl and scrape websites using Crawlee and Parsel. Start from a URL and store results to your Apify dataset.",
             "messages": {
                 "postCreate": "To install additional Python packages, you need to activate the virtual environment in the \".venv\" folder in the actor directory."
             },
@@ -183,7 +191,7 @@
             "label": "Crawlee + Playwright + Chrome",
             "category": "python",
             "technologies": ["crawlee", "playwright"],
-            "description": "Crawl and scrape websites using Crawlee and Playwright. Start from a given start URLs, and store results to Apify dataset.",
+            "description": "Crawl and scrape websites using Crawlee and Playwright. Start from a URL and store results to your Apify dataset.",
             "messages": {
                 "postCreate": "To install additional Python packages, you need to activate the virtual environment in the \".venv\" folder in the actor directory."
             },
@@ -203,7 +211,7 @@
             "label": "Crawlee + Playwright + Camoufox",
             "category": "python",
             "technologies": ["crawlee", "playwright", "camoufox"],
-            "description": "Crawl and scrape websites using Crawlee and Playwright with Camoufox. Start from a given start URLs, and store results to Apify dataset.",
+            "description": "Crawl and scrape websites using Crawlee and Playwright with Camoufox. Start from a URL and store results to your Apify dataset.",
             "messages": {
                 "postCreate": "To install additional Python packages, you need to activate the virtual environment in the \".venv\" folder in the actor directory."
             },
@@ -270,7 +278,7 @@
                 "timeoutSecs": 600
             },
             "showcaseFiles": ["my_actor/main.py", "my_actor/agent.py", "my_actor/tools.py", "my_actor/__main__.py"],
-            "useCases": ["AI"]
+            "useCases": ["AI", "WEB_SCRAPING"]
         },
         {
             "id": "python-pydanticai",
@@ -294,7 +302,7 @@
             "label": "Smolagents agent",
             "category": "python",
             "technologies": ["smolagents"],
-            "description": "An AI news aggregator that fetches and summarizes the latest news based on user-defined interests using DuckDuckGo search and OpenAI models written in Python Smolagents.",
+            "description": "Create an AI news aggregator that fetches and summarizes the latest news based on your interests, using DuckDuckGo search and OpenAI models with Python Smolagents.",
             "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/python-pydanticai.zip?raw=true",
             "defaultRunOptions": {
                 "build": "latest",
@@ -327,7 +335,7 @@
                 "my_actor/server.py",
                 "my_actor/__main__.py"
             ],
-            "useCases": ["AI"]
+            "useCases": ["AI", "INTEGRATION"]
         },
         {
             "id": "python-mcp-empty",
@@ -344,7 +352,7 @@
                 "timeoutSecs": 60
             },
             "showcaseFiles": ["my_actor/main.py", "my_actor/__main__.py"],
-            "useCases": ["AI"]
+            "useCases": ["AI", "INTEGRATION"]
         },
         {
             "id": "js-crawlee-cheerio",
@@ -459,7 +467,7 @@
             },
             "skipOptionalDeps": true,
             "showcaseFiles": ["src/main.js", "src/routes.js"],
-            "useCases": ["WEB_SCRAPING"]
+            "useCases": ["STARTER", "WEB_SCRAPING"]
         },
         {
             "id": "ts-start",
@@ -540,7 +548,7 @@
                 "timeoutSecs": 3600
             },
             "showcaseFiles": ["src/main.ts", "src/runCodegen.ts", "src/transform.ts"],
-            "useCases": ["WEB_SCRAPING"]
+            "useCases": ["AUTOMATION", "INTEGRATION"]
         },
         {
             "id": "ts-empty",
@@ -556,7 +564,7 @@
                 "timeoutSecs": 3600
             },
             "showcaseFiles": ["src/main.ts"],
-            "useCases": ["WEB_SCRAPING"]
+            "useCases": ["STARTER"]
         },
         {
             "id": "ts-standby",
@@ -573,7 +581,7 @@
                 "timeoutSecs": 3600
             },
             "showcaseFiles": ["src/main.ts"],
-            "useCases": ["STARTER"]
+            "useCases": ["STARTER", "INTEGRATION"]
         },
         {
             "id": "js-cypress",
@@ -610,7 +618,7 @@
                 "timeoutSecs": 3600
             },
             "showcaseFiles": ["src/main.js"],
-            "useCases": ["WEB_SCRAPING"]
+            "useCases": ["STARTER"]
         },
         {
             "id": "js-standby",
@@ -627,7 +635,7 @@
                 "timeoutSecs": 3600
             },
             "showcaseFiles": ["src/main.js"],
-            "useCases": ["STARTER"]
+            "useCases": ["STARTER", "INTEGRATION"]
         },
         {
             "id": "js-langchain",
@@ -635,7 +643,7 @@
             "label": "🦜️🔗 LangChain",
             "category": "javascript",
             "technologies": ["nodejs", "langchain"],
-            "description": "Example of how to use LangChain.js with Apify to crawl the web data, vectorize them, and prompt the OpenAI model.",
+            "description": "Example of how to use LangChain.js with Apify to crawl, vectorize, and query web data with the OpenAI model.",
             "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/js-langchain.zip?raw=true",
             "defaultRunOptions": {
                 "build": "latest",
@@ -643,7 +651,7 @@
                 "timeoutSecs": 3600
             },
             "showcaseFiles": ["src/main.js", "src/vector_index_cache.js"],
-            "useCases": ["AI"]
+            "useCases": ["AI", "WEB_SCRAPING"]
         },
         {
             "id": "js-langgraph-agent",
@@ -724,7 +732,7 @@
             },
             "skipTests": true,
             "showcaseFiles": ["src/main.ts", "src/billing.ts"],
-            "useCases": ["AI"]
+            "useCases": ["AI", "INTEGRATION"]
         },
         {
             "id": "ts-mcp-empty",
@@ -741,7 +749,7 @@
             },
             "skipTests": true,
             "showcaseFiles": ["src/main.ts"],
-            "useCases": ["AI"]
+            "useCases": ["AI", "INTEGRATION"]
         },
         {
             "id": "cli-start",
@@ -749,7 +757,7 @@
             "label": "CLI-based Actor starter",
             "category": "javascript",
             "technologies": ["jq"],
-            "description": "Actorize a CLI utility with the Apify Actor CLI",
+            "description": "Turn any CLI utility into an Apify Actor using the Apify CLI.",
             "archiveUrl": "https://github.com/apify/actor-templates/blob/master/dist/templates/cli-start.zip?raw=true",
             "defaultRunOptions": {
                 "build": "latest",
@@ -757,7 +765,8 @@
                 "timeoutSecs": 600
             },
             "showcaseFiles": ["main.sh"],
-            "skipTests": true
+            "skipTests": true,
+            "useCases": ["STARTER", "INTEGRATION", "AUTOMATION"]
         }
     ]
 }


### PR DESCRIPTION
## Summary

Refines the `useCases` tags across Actor templates so the Console wizard's "use case + language" filter produces a meaningful split, polishes a handful of template descriptions, and adds in-place documentation for what each use case represents.

## Changes

### `useCases` tag refinements

- `python/ts/js-empty`: `[WEB_SCRAPING]` → `[STARTER]` (empties are topic-agnostic, not scrapers).
- `python/ts/js-standby` (×3): added `INTEGRATION` to `[STARTER]` (Standby actors serve HTTP, callable by outside systems).
- `python-mcp-proxy`, `python-mcp-empty`, `ts-mcp-proxy`, `ts-mcp-empty` (×4): added `INTEGRATION` to `[AI]` (callable by AI clients via the MCP protocol).
- `ts-playwright-test-runner`: `[WEB_SCRAPING]` → `[AUTOMATION]` (it's a test runner — automation, not scraping).
- `python-playwright` / `python-selenium`: added `AUTOMATION` to `[WEB_SCRAPING]` (pure browser tooling without a scraping framework — repurposable for automation).
- `cli-start`: filled in the previously missing `useCases` with `[STARTER, INTEGRATION]` (the Dockerfile sets up `ubi` to install third-party binaries — Actorization is integration).

### Description polish

- Rewritten descriptions for 9 templates (`python-crawlee-beautifulsoup`, `python-empty`, `python-standby`, `python-crawlee-parsel`, `python-crawlee-playwright`, `python-crawlee-playwright-camoufox`, `python-smolagents`, `js-langchain`, `cli-start`) — clearer, more direct phrasing, and consistent grammar (e.g. "Start from a given start URLs" → "Start from a URL").

### Documentation

- Added `_useCaseDescriptions` field at the manifest top-level — a self-contained reference for what each tag represents. Canonical enum + JSDoc lives in `apify-core` (`TEMPLATE_USE_CASES` in `src/packages/consts/src/templates.ts`).

## Tagging principles applied

The tagging principle is: **tag for what the template IS (its primary framing/purpose), not what it COULD become.** Concretely:

- **Empty scaffolds** carry only `STARTER` (no inherent topic).
- **`STARTER`** is for entry-level / first-Actor scaffolds. Skeletons explicitly aimed at experienced devs don't qualify.
- **Pure browser tooling** (raw Playwright / Selenium, no Crawlee wrapping) can earn `AUTOMATION` in addition to `WEB_SCRAPING` — the underlying tool is genuinely repurposable.
- **Crawlee variants** stay `WEB_SCRAPING` only — Crawlee's crawler-specific abstractions (request queue, `*Crawler` classes) orient the project toward scraping, even when paired with Playwright/Puppeteer.
- **AI agents** stay `AI`-only, even when they crawl as part of their workflow. Calling Apify Actors as tools or fetching web data is a means; the AI framework demo is the product.
- **`INTEGRATION`** is reserved for templates that meaningfully bridge Apify with external systems: Standby HTTP servers, MCP servers callable by AI clients, or third-party-tool wrappers (`cli-start`). Not "any Actor that has an API surface" — that would be everything.

## Coverage after changes

**Use case → templates**

| Use case | Count |
|---|---|
| `WEB_SCRAPING` | 21 |
| `STARTER` | 17 |
| `AI` | 13 |
| `INTEGRATION` | 8 |
| `AUTOMATION` | 4 |

**Use case × language**

| Use case | JavaScript | Python | TypeScript | Total |
|---|---|---|---|---|
| `WEB_SCRAPING` | 6 | 9 | 6 | 21 |
| `STARTER` | 5 | 7 | 5 | 17 |
| `AI` | 2 | 7 | 4 | 13 |
| `INTEGRATION` | 2 | 3 | 3 | 8 |
| `AUTOMATION` | 1 | 2 | 1 | 4 |

## Open for refinement

This pass focused on obvious mistags and missing tags. Further iteration welcome — especially around:

- **JS / TS `AUTOMATION` = 1 each** — `js-cypress` and `ts-playwright-test-runner` respectively. Both are test runners. No general-purpose JS/TS browser-automation template exists; an equivalent of `python-playwright`/`python-selenium` for each would fill the gap.
- **JS `INTEGRATION` = 2** — `js-standby` + `cli-start`. No JS MCP template exists; adding one would mirror the Python/TS coverage.
- **Individual template judgement calls** — tagging is partly subjective. Happy to iterate on any specific template.

No changes to template content or behavior — only metadata in `manifest.json`.
