### PR TITLE
fix(scrapy): make scrapy template spider middleware async-compatible

### DIFF
--- a/templates/python-scrapy/my_actor/middlewares.py
+++ b/templates/python-scrapy/my_actor/middlewares.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 from scrapy import Request, Spider, signals
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Iterable
+    from collections.abc import AsyncGenerator, AsyncIterable, Iterable
 
     from scrapy.crawler import Crawler
     from scrapy.http.response import Response
@@ -43,17 +43,17 @@ class TitleSpiderMiddleware:
         # Should return None or raise an exception.
         return None
 
-    def process_spider_output(
+    async def process_spider_output(
         self,
         response: Response,
-        result: Iterable,
+        result: AsyncIterable,
         spider: Spider,
-    ) -> Generator[Iterable[Request] | None, None, None]:
+    ) -> AsyncGenerator[Iterable[Request] | None, None]:
         # Called with the results returned from the Spider, after
         # it has processed the response.
 
         # Must return an iterable of Request, or item objects.
-        for i in result:
+        async for i in result:
             yield i
 
     def process_spider_exception(


### PR DESCRIPTION
## Summary

Scrapy 2.16.0 promotes the previously-warned check for asynchronous spider output to a hard error: a middleware used with `AsyncCrawlerRunner` must expose `process_spider_output` as an async generator (or define a separate `process_spider_output_async` method). The python-scrapy template's `TitleSpiderMiddleware.process_spider_output` was still a plain sync generator, so `apify run` aborted at engine init with `TypeError: Middleware … doesn't support asynchronous spider output`, no dataset was written, and the apify-cli `python-scrapy-template-works` API test failed across every Python/OS matrix (e.g. https://github.com/apify/apify-cli/actions/runs/26149888976/job/76914412480).

This converts the method to an `async def` generator (`async for i in result: yield i`) and updates the type hints (`AsyncIterable` / `AsyncGenerator`). Verified locally with `apify 3.4.0` + `scrapy 2.16.0`: actor exits 0 and the default dataset contains 14 items.

The Scrapy 2.16 deprecation warnings about middleware/pipeline methods requiring a `spider` argument are intentionally left for a separate cleanup — the template pins `scrapy < 3.0.0` and those are only warnings today.