### PR TITLE
fix(ts-beeai-agent): drop vulnerable @langchain/community, migrate LLM to Apify OpenRouter proxy

### DIFF
--- a/templates/ts-beeai-agent/.actor/input_schema.json
+++ b/templates/ts-beeai-agent/.actor/input_schema.json
@@ -13,12 +13,12 @@
             "default": "This is a fallback test query, do nothing and !!do not call any tools!!. If asked to generate structured response, create a dummy one without optional fields - minimal as possible."
         },
         "modelName": {
-            "title": "OpenAI model",
+            "title": "LLM model (OpenRouter)",
             "type": "string",
-            "description": "The OpenAI model to use. Currently supported models are gpt-4o and gpt-4o-mini.",
-            "enum": ["gpt-4o", "gpt-4o-mini"],
-            "default": "gpt-4o-mini",
-            "prefill": "gpt-4o-mini"
+            "description": "Model ID routed through the Apify OpenRouter proxy (https://apify.com/apify/openrouter). Tokens are charged automatically to your Apify account, so no provider API key is needed.",
+            "enum": ["deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro", "moonshotai/kimi-k2.6", "z-ai/glm-5.1"],
+            "default": "deepseek/deepseek-v4-flash",
+            "prefill": "deepseek/deepseek-v4-flash"
         },
         "debug": {
             "title": "Debug",

--- a/templates/ts-beeai-agent/.npmrc
+++ b/templates/ts-beeai-agent/.npmrc
@@ -1,1 +1,7 @@
 min-release-age=1
+
+; beeai-framework declares optional peer deps (LangChain, vector DBs, cloud
+; SDKs) that pull in mutually incompatible @langchain/core versions. We use
+; only the OpenAI adapter, so none of them get installed, but npm still tries
+; to satisfy the optional peers and fails. legacy-peer-deps relaxes that.
+legacy-peer-deps=true

--- a/templates/ts-beeai-agent/Dockerfile
+++ b/templates/ts-beeai-agent/Dockerfile
@@ -6,9 +6,11 @@ FROM apify/actor-node:24 AS builder
 # Check preinstalled packages
 RUN npm ls apify
 
-# Copy just package.json and package-lock.json
-# to speed up the build using Docker layer cache.
-COPY --chown=myuser:myuser package*.json ./
+# Copy just package.json, package-lock.json, and .npmrc
+# to speed up the build using Docker layer cache. .npmrc is needed
+# because beeai-framework declares mutually-incompatible optional peer
+# deps (LangChain, vector DBs, ...) that require legacy-peer-deps=true.
+COPY --chown=myuser:myuser package*.json .npmrc ./
 
 # Install all dependencies. Don't audit to speed up the installation.
 RUN npm install --include=dev --audit=false
@@ -27,9 +29,9 @@ FROM apify/actor-node:24
 # Check preinstalled packages
 RUN npm ls apify
 
-# Copy just package.json and package-lock.json
+# Copy just package.json, package-lock.json, and .npmrc
 # to speed up the build using Docker layer cache.
-COPY --chown=myuser:myuser package*.json ./
+COPY --chown=myuser:myuser package*.json .npmrc ./
 
 # Install NPM packages, skip optional and development dependencies to
 # keep the image small. Avoid logging too much and print the dependency

--- a/templates/ts-beeai-agent/README.md
+++ b/templates/ts-beeai-agent/README.md
@@ -8,9 +8,15 @@ A template for [BeeAI agent](https://beeai.dev/) projects in TypeScript for buil
 
 A [ReAct agent](https://react-lm.github.io/) is employed, equipped with tools to respond to user queries. The agent processes a user query, decides on the tools to use, and in what sequence, to achieve the desired outcome. Here, the agent leverages an Instagram Scraper to fetch posts from a profile and a calculator tool to compute sums, such as totaling likes or comments. The agent produces textual and structured output, which is saved to a dataset.
 
+### LLM provider
+
+The agent talks to its LLM through the [Apify OpenRouter proxy](https://apify.com/apify/openrouter) — an OpenAI-compatible endpoint at `https://openrouter.apify.actor/api/v1` that fronts the full [OpenRouter](https://openrouter.ai) model catalog. Token usage is billed against the user's Apify account (pay-per-event), so **no `OPENAI_API_KEY` or any other provider API key is required**. The Actor authenticates with the proxy using the `APIFY_TOKEN` that the platform injects into every run automatically.
+
+If you'd rather call OpenAI / Anthropic / etc. directly with your own key, swap the `OpenAIChatModel` configuration in `src/main.ts` for a different `baseURL` / `apiKey` / provider adapter — see the [BeeAI backend docs](https://framework.beeai.dev/modules/backend).
+
 ### How to Use
 
-Add or modify tools in the `src/tool_calculator.ts` and `src/tool_instagram.ts` files, and ensure they are included in the agent's tool list in `src/main.ts`. Additionally, you can update the agent's system prompt or other configurations within `src/main.ts`. For more information, refer to the [BeeAI documentation](https://docs.beeai.dev/concepts/agents).
+Add or modify tools in `src/tools/calculator.ts` and `src/tools/instagram.ts`, and register them in the agent's tool list in `src/main.ts`. You can also adjust the agent's system prompt or other configuration in `src/main.ts`. For more details, see the [BeeAI framework agents documentation](https://framework.beeai.dev/modules/agents).
 
 #### Pay Per Event
 
@@ -40,8 +46,9 @@ This approach allows you to programmatically charge users directly from your Act
 
 To set up the PPE model for this Actor:
 
-- **Configure the OpenAI API key environment variable**: provide your OpenAI API key to the `OPENAI_API_KEY` in the Actor's **Environment variables**.
 - **Configure Pay Per Event**: establish the Pay Per Event pricing schema in the Actor's **Monetization settings**. First, set the **Pricing model** to `Pay per event` and add the schema. An example schema can be found in [pay_per_event.json](.actor/pay_per_event.json).
+
+No provider API key (e.g. `OPENAI_API_KEY`) needs to be configured — LLM costs are billed through the Apify OpenRouter proxy to the user running the Actor.
 
 ### Included Features
 
@@ -55,5 +62,5 @@ To set up the PPE model for this Actor:
 - [What are AI agents?](https://blog.apify.com/what-are-ai-agents/)
 - [TypeScript tutorials in Academy](https://docs.apify.com/academy/node-js)
 - [Apify SDK documentation](https://docs.apify.com/sdk/js/)
-- [BeeAI documentation](https://docs.beeai.dev/introduction/welcome)
+- [BeeAI framework documentation](https://framework.beeai.dev/introduction/welcome)
 - [Integration with Make, GitHub, Zapier, Google Drive, and other apps](https://apify.com/integrations)

--- a/templates/ts-beeai-agent/package.json
+++ b/templates/ts-beeai-agent/package.json
@@ -7,25 +7,23 @@
         "node": ">=18.0.0"
     },
     "dependencies": {
-        "@ai-sdk/openai": "^1.3.24",
-        "@langchain/community": "0.2.31",
-        "@langchain/openai": "0.3.16",
-        "apify": "^3.7.0",
-        "beeai-framework": "0.1.20",
-        "zod": "^3.25.67"
+        "@ai-sdk/openai": "3.0.63",
+        "apify": "^3.7.2",
+        "beeai-framework": "^0.1.29",
+        "zod": "^3.25.76"
     },
     "devDependencies": {
-        "@apify/eslint-config": "^2.0.0",
+        "@apify/eslint-config": "^2.0.6",
         "@apify/tsconfig": "^0.1.1",
         "@types/node": "^24.0.0",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
-        "globals": "^17.2.0",
-        "prettier": "^3.8.1",
-        "tsx": "^4.21.0",
-        "typescript": "^6.0.0",
-        "typescript-eslint": "^8.58.0",
-        "vitest": "^4.1.0"
+        "globals": "^17.6.0",
+        "prettier": "^3.8.3",
+        "tsx": "^4.22.3",
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.60.0",
+        "vitest": "^4.1.7"
     },
     "scripts": {
         "start": "npm run start:dev",

--- a/templates/ts-beeai-agent/src/main.ts
+++ b/templates/ts-beeai-agent/src/main.ts
@@ -1,6 +1,4 @@
-import { ChatOpenAI } from '@langchain/openai';
 import { Actor, log } from 'apify';
-import { LangChainChatModel } from 'beeai-framework/adapters/langchain/backend/chat';
 import { OpenAIChatModel } from 'beeai-framework/adapters/openai/backend/chat';
 import { ReActAgent } from 'beeai-framework/agents/react/agent';
 import { UnconstrainedMemory } from 'beeai-framework/memory/unconstrainedMemory';
@@ -47,15 +45,22 @@ if (!query) {
  * Actor code
  */
 // Create an agent that can use tools.
-// See https://i-am-bee.github.io/beeai-framework/#/agents?id=react-agent
-// To use PPE, the LangChain adapter must be used
-// otherwise, the token usage is not tracked.
+// See https://framework.beeai.dev/modules/agents
+//
+// The LLM is routed through the Apify-hosted OpenRouter proxy
+// (https://apify.com/apify/openrouter): an OpenAI-compatible endpoint billed
+// against the user's Apify account, so no provider API key is needed. The
+// proxy authenticates via the `Authorization` header, not the `apiKey` field.
 log.debug(`Using model: ${modelName}`);
-const llm = new LangChainChatModel(new ChatOpenAI({ model: modelName }));
-// The LangChain adapter does not work with the structured output generation
-// for some reason.
-// Create a separate LLM for structured output generation.
-const llmStructured = new OpenAIChatModel(modelName);
+const llm = new OpenAIChatModel(
+    modelName,
+    {},
+    {
+        baseURL: 'https://openrouter.apify.actor/api/v1',
+        apiKey: 'apify-openrouter-proxy', // unused by the proxy; OpenAI SDK rejects an empty string
+        headers: { Authorization: `Bearer ${process.env.APIFY_TOKEN}` },
+    },
+);
 const agent = new ReActAgent({
     llm,
     memory: new UnconstrainedMemory(),
@@ -64,7 +69,7 @@ const agent = new ReActAgent({
 
 // Store tool messages for later structured output generation.
 // This can be removed if you don't need structured output.
-const structuredOutputGenerator = new StructuredOutputGenerator(llmStructured);
+const structuredOutputGenerator = new StructuredOutputGenerator(llm);
 
 // Prompt the agent with the query.
 // Debug log agent status updates, e.g., thoughts, tool calls, etc.

--- a/templates/ts-beeai-agent/src/main.ts
+++ b/templates/ts-beeai-agent/src/main.ts
@@ -8,6 +8,12 @@ import { StructuredOutputGenerator } from './structured_response_generator.js';
 import { CalculatorSumTool } from './tools/calculator.js';
 import { InstagramScrapeTool } from './tools/instagram.js';
 
+// Apify-hosted OpenRouter proxy (https://apify.com/apify/openrouter): an
+// OpenAI-compatible endpoint billed against the user's Apify account, so no
+// provider API key is needed. The proxy authenticates via the `Authorization`
+// header carrying the run's APIFY_TOKEN.
+const OPENROUTER_BASE_URL = 'https://openrouter.apify.actor/api/v1';
+
 // This is an ESM project, and as such, it requires you to specify extensions in your relative imports.
 // Read more about this here: https://nodejs.org/docs/latest-v18.x/api/esm.html#mandatory-file-extensions
 // Note that we need to use `.js` even when inside TS files
@@ -46,17 +52,12 @@ if (!query) {
  */
 // Create an agent that can use tools.
 // See https://framework.beeai.dev/modules/agents
-//
-// The LLM is routed through the Apify-hosted OpenRouter proxy
-// (https://apify.com/apify/openrouter): an OpenAI-compatible endpoint billed
-// against the user's Apify account, so no provider API key is needed. The
-// proxy authenticates via the `Authorization` header, not the `apiKey` field.
 log.debug(`Using model: ${modelName}`);
 const llm = new OpenAIChatModel(
     modelName,
     {},
     {
-        baseURL: 'https://openrouter.apify.actor/api/v1',
+        baseURL: OPENROUTER_BASE_URL,
         apiKey: 'apify-openrouter-proxy', // unused by the proxy; OpenAI SDK rejects an empty string
         headers: { Authorization: `Bearer ${process.env.APIFY_TOKEN}` },
     },


### PR DESCRIPTION
## Context

`templates/ts-beeai-agent/` pinned `@langchain/community@0.2.31`, which is flagged with a known vulnerability and is also long-unmaintained. The template also forced users to set `OPENAI_API_KEY` even though they're already paying with Apify credits.

## Solution

Drop both LangChain packages (only used to wrap `ChatOpenAI` for the LangChain adapter), upgrade `beeai-framework 0.1.20 → ^0.1.29` and its companion `@ai-sdk/openai → 3.0.63`, and route the LLM through the [Apify OpenRouter proxy](https://apify.com/apify/openrouter) so token cost is billed automatically against the user's Apify account — no provider API key needed. The proxy authenticates via an `Authorization: Bearer $APIFY_TOKEN` header.

## Worth your attention

- **`legacy-peer-deps=true`** in `.npmrc` (and copied into both Dockerfile stages). `beeai-framework@0.1.29` lists `@langchain/community@^0.2.28`, `@qdrant/...`, etc. as *optional* peer deps, but npm still tries to resolve them and `@langchain/community@0.2.x` drags in an old `@langchain/core` that conflicts with the rest of the tree. Without this, both local install and the Actor docker build fail with `ERESOLVE`.
- **`@ai-sdk/openai` pinned to exact `3.0.63`** (not `^3.0.63`). Caret was resolving to `3.0.66`, which fails the 14-day freshness rule (published 2026-05-27, one day old at time of writing). `3.0.63` is the newest version that is ≥14 days old and still satisfies beeai's peer constraint.
- **`modelName` enum switched to OpenRouter slugs** (`deepseek/...`, `moonshotai/kimi-k2.6`, `z-ai/glm-5.1`). Old `gpt-4o`/`gpt-4o-mini` values would no longer route correctly through the proxy.
- **README path typo fixed** — pre-existing bug: it referenced `src/tool_calculator.ts` and `src/tool_instagram.ts`; the actual files live at `src/tools/calculator.ts` and `src/tools/instagram.ts`.
- **Outdated docs links replaced** — `i-am-bee.github.io/beeai-framework` 404s; `docs.beeai.dev` now redirects to `agentstack.beeai.dev` (the runtime, not the TS framework). Pointed at `framework.beeai.dev` instead.

## Follow-up

- 3 moderate `file-type` advisories remain via `apify → @crawlee/*` — unrelated; out of scope.
