### PR TITLE
ci: restrict default GITHUB_TOKEN to contents:read in update-templates workflow

### DIFF
--- a/.github/workflows/update-templates.yml
+++ b/.github/workflows/update-templates.yml
@@ -26,6 +26,9 @@ env:
   DEFAULT_RUNTIME_VERSION: ${{ github.event.client_payload.default_runtime_version || inputs.default_runtime_version }}
   MODULE_VERSION: ${{ github.event.client_payload.module_version || inputs.module_version }}
 
+permissions:
+  contents: read
+
 jobs:
   update-templates:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes code-scanning alert https://github.com/apify/actor-templates/security/code-scanning/15 actions/missing-workflow-permissions).
All privileged operations in this workflow already use the explicit
APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN PAT; the default GITHUB_TOKEN is unused
and can be safely locked down to least privilege.
