### PR TITLE
fix(js-cypress): stop tests depending on the apify.com marketing site

### DIFF
--- a/templates/js-cypress/.actor/input_schema.json
+++ b/templates/js-cypress/.actor/input_schema.json
@@ -10,7 +10,7 @@
             "type": "string",
             "description": "Base url for the tests.",
             "editor": "textfield",
-            "prefill": "https://apify.com"
+            "prefill": "https://example.com"
         },
         "viewportWidth": {
             "title": "Viewport width",

--- a/templates/js-cypress/README.md
+++ b/templates/js-cypress/README.md
@@ -15,6 +15,8 @@ Run your [Cypress tests](https://www.cypress.io/) on the Apify Platform effectiv
 
 You can easily run your tests on the Apify Platform, just copy-paste your test files into `cypress/e2e` folder. The tests' names need to end with `-spec.cy.js`.
 
+The bundled example specs visit [`https://example.com`](https://example.com) — a stable site reserved for documentation — so the demo passes reliably out of the box. Point the tests at your own site by setting the `baseUrl` input (or editing `baseUrl` in `cypress.config.js`); `cy.visit('/')` then resolves against it.
+
 You can also customize the test run by specifying other options in the input, e.g. the screen size, video recording, or the default command timeout.
 
 After running the tests, the Apify platform stores the results in a comprehensive way - datasets for JSON results, and key-value store for videos. You can view the results directly on the platform or download them to your local machine using a REST API.

--- a/templates/js-cypress/cypress.config.js
+++ b/templates/js-cypress/cypress.config.js
@@ -4,6 +4,7 @@ import { defineConfig } from 'cypress';
 export default defineConfig({
     e2e: {
         // to be able to run the tests locally for Apify CLI versions 17.0.0 and older
-        baseUrl: 'https://apify.com',
+        // Defaults to a stable demo site; override it via the Actor `baseUrl` input.
+        baseUrl: 'https://example.com',
     },
 });

--- a/templates/js-cypress/cypress/e2e/first-spec.cy.js
+++ b/templates/js-cypress/cypress/e2e/first-spec.cy.js
@@ -1,7 +1,9 @@
 describe('first tests suite', () => {
-    it('visit Apify main page', () => {
+    it('visits the homepage', () => {
+        // `baseUrl` is configured in cypress.config.js (and overridable from the
+        // Actor input), so cy.visit('/') hits whatever site you point it at.
         cy.visit('/');
-        cy.log('Visiting Apify main page');
-        cy.contains('div', 'Apify').should('exist');
+        cy.log('Visiting the homepage');
+        cy.contains('h1', 'Example Domain').should('be.visible');
     });
 });

--- a/templates/js-cypress/cypress/e2e/second-spec.cy.js
+++ b/templates/js-cypress/cypress/e2e/second-spec.cy.js
@@ -1,9 +1,11 @@
 describe('second tests suite', () => {
-    it('visit apify store', () => {
-        cy.visit('/store');
-        cy.log('Visiting Apify Store, clicking on Actor');
-        cy.contains('.ActorStoreItem-title', 'Web Scraper').should('be.visible').click();
-        cy.log('Asserting store Actor redirect');
-        cy.url().should('eq', 'https://apify.com/apify/web-scraper');
+    it('finds the outbound link', () => {
+        cy.visit('/');
+        cy.log('Locating the outbound link by its target');
+        // Select the link by its href attribute rather than its text. This is
+        // robust to copy changes on the page (the visible label may differ) and
+        // demonstrates asserting on an attribute instead of clicking through to
+        // another domain, which Cypress restricts across origins.
+        cy.get('a[href*="iana.org"]').should('be.visible');
     });
 });

--- a/templates/js-cypress/cypress/support/e2e.js
+++ b/templates/js-cypress/cypress/support/e2e.js
@@ -12,3 +12,11 @@
 // You can read more here:
 // https://on.cypress.io/guides/configuration#section-global
 // ***********************************************************
+
+// By default Cypress fails the test if the visited page throws an uncaught
+// exception (e.g. a minified React hydration error like #418:
+// https://react.dev/errors/418). For an end-to-end demo we only care that the
+// page loads and our assertions pass, not that the site's own JavaScript is
+// bug-free, so we swallow page-level exceptions and let the test continue.
+// Remove this if you want your own tests to fail on the visited site's errors.
+Cypress.on('uncaught:exception', () => false);

--- a/templates/js-cypress/src/main.js
+++ b/templates/js-cypress/src/main.js
@@ -18,7 +18,7 @@ import { globby } from 'globby';
 await Actor.init();
 
 // Define the configuration to start the cypress test with - get it from the input of the Actor or use a default config.
-const input = (await Actor.getInput()) || { baseUrl: 'https://apify.com', video: true };
+const input = (await Actor.getInput()) || { baseUrl: 'https://example.com', video: true };
 log.info(`Running tests with following input: ${JSON.stringify(input)}`);
 
 // Helper function to run tests from specific test file with given configuration from INPUT.json


### PR DESCRIPTION
## Problem

The `js-cypress` template's example specs hit the **live apify.com marketing site**, so the template's CI broke whenever that site changed — even though the template itself was untouched:

- `first-spec.cy.js` → `cy.visit('/')`, asserted `cy.contains('div', 'Apify')`
- `second-spec.cy.js` → `cy.visit('/store')`, clicked `.ActorStoreItem-title` containing `Web Scraper`, asserted a redirect to `https://apify.com/apify/web-scraper`

The harness runs these for real: `js-cypress` is **not** in `SKIP_TESTS`, and `checkTemplateRun()` (`test/templates.test.js:156`) executes `apify run`, which runs `src/main.js` → `cypress.run()` against the configured site.

Observed failure on PR #806 / [run 27280506506](https://github.com/apify/actor-templates/actions/runs/27280506506) (windows-latest, node 24):
- first-spec: minified **React #418** hydration error on apify.com auto-failed the test.
- second-spec: `.ActorStoreItem-title` selector timed out after 30s.

It's demo code — it shouldn't depend on production marketing markup the template repo doesn't control.

## Fix

Repoint the demo at **`https://example.com`** (IANA / RFC-2606 reserved for documentation — stable markup, no app JS) and harden the specs:

- **first-spec** → asserts the stable `Example Domain` heading.
- **second-spec** → selects the outbound link by `a[href*="iana.org"]` instead of by visible text, and asserts visibility — no cross-origin click. (While testing I found example.com now serves a `Learn more` link variant rather than the old `More information...`; the attribute selector is robust to that copy churn.)
- **`cypress/support/e2e.js`** → `Cypress.on('uncaught:exception', () => false)`, documented with a link to the [React error docs](https://react.dev/errors/418), so a broken JS handler on the visited page can't auto-fail the demo.
- Updated `baseUrl` default/prefill in `cypress.config.js`, `src/main.js`, and `.actor/input_schema.json`, and documented the new target + how to override it via the `baseUrl` input in the README.

Scope is limited to `templates/js-cypress/**`; the Apify SDK + Cypress wiring (input schema, dataset/KVS result storage, video recording) is unchanged, so the template still teaches the same thing.

## Verification

Done locally on the final files (in an isolated copy, mirroring `prepareActor`'s `fs.cpSync` to a tmp dir):
- `npm install`, `npm run lint`, `npm run format:check` — all pass.
- `node --check` on every touched JS file; JSON files parse.
- Confirmed the asserted elements (`<h1>Example Domain</h1>` and a link with `href*="iana.org"`) exist in the live `example.com` HTML across its served variants.

The actual headless browser run can't execute in my sandbox (no Xvfb / no root). **Relying on this PR's CI matrix** (ubuntu-24.04 + windows-latest, Node 22/24) for the cross-OS browser run — please confirm two consecutive green runs, with attention to the Windows job that was flaky on timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)