### PR TITLE
feat: add .actorignore to all templates and populate dataset_schema.json fields

### DIFF
--- a/templates/cli-start/.actorignore
+++ b/templates/cli-start/.actorignore
@@ -1,0 +1,9 @@
+# .actorignore — files NOT included in `apify push` archives.
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+.git/

--- a/templates/js-bootstrap-cheerio-crawler/.actor/dataset_schema.json
+++ b/templates/js-bootstrap-cheerio-crawler/.actor/dataset_schema.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
+    "actorSpecification": 1,
+    "fields": {
+        "title": "Pages",
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "title",
+            "url"
+        ]
+    },
+    "views": {
+        "overview": {
+            "title": "Overview",
+            "transformation": {
+                "fields": [
+                    "title",
+                    "url"
+                ]
+            },
+            "display": {
+                "component": "table",
+                "properties": {
+                    "title": {
+                        "label": "Title",
+                        "format": "text"
+                    },
+                    "url": {
+                        "label": "URL",
+                        "format": "link"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/templates/js-bootstrap-cheerio-crawler/.actorignore
+++ b/templates/js-bootstrap-cheerio-crawler/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/js-crawlee-cheerio/.actor/dataset_schema.json
+++ b/templates/js-crawlee-cheerio/.actor/dataset_schema.json
@@ -1,12 +1,33 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "title",
+            "url"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["title", "url"]
+                "fields": [
+                    "title",
+                    "url"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/js-crawlee-cheerio/.actorignore
+++ b/templates/js-crawlee-cheerio/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/js-crawlee-playwright-camoufox/.actor/dataset_schema.json
+++ b/templates/js-crawlee-playwright-camoufox/.actor/dataset_schema.json
@@ -1,12 +1,33 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "title",
+            "url"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["title", "url"]
+                "fields": [
+                    "title",
+                    "url"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/js-crawlee-playwright-camoufox/.actorignore
+++ b/templates/js-crawlee-playwright-camoufox/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/js-crawlee-playwright-chrome/.actor/dataset_schema.json
+++ b/templates/js-crawlee-playwright-chrome/.actor/dataset_schema.json
@@ -1,12 +1,33 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "title",
+            "url"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["title", "url"]
+                "fields": [
+                    "title",
+                    "url"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/js-crawlee-playwright-chrome/.actorignore
+++ b/templates/js-crawlee-playwright-chrome/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/js-crawlee-puppeteer-chrome/.actor/dataset_schema.json
+++ b/templates/js-crawlee-puppeteer-chrome/.actor/dataset_schema.json
@@ -1,12 +1,33 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "title",
+            "url"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["title", "url"]
+                "fields": [
+                    "title",
+                    "url"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/js-crawlee-puppeteer-chrome/.actorignore
+++ b/templates/js-crawlee-puppeteer-chrome/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/js-cypress/.actor/dataset_schema.json
+++ b/templates/js-cypress/.actor/dataset_schema.json
@@ -1,7 +1,50 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Filtered output",
+        "type": "object",
+        "properties": {
+            "testSuiteTitle": {
+                "type": "string",
+                "title": "Test Suite Title"
+            },
+            "totalDuration": {
+                "type": "number",
+                "title": "Total Duration"
+            },
+            "totalFailed": {
+                "type": "number",
+                "title": "Total Failed"
+            },
+            "totalPassed": {
+                "type": "string",
+                "title": "Total Passed"
+            },
+            "totalPending": {
+                "type": "number",
+                "title": "Total Pending"
+            },
+            "totalSkipped": {
+                "type": "number",
+                "title": "Total Skipped"
+            },
+            "videoLink": {
+                "type": "string",
+                "format": "uri",
+                "title": "Video recording"
+            }
+        },
+        "required": [
+            "testSuiteTitle",
+            "totalDuration",
+            "totalFailed",
+            "totalPassed",
+            "totalPending",
+            "totalSkipped",
+            "videoLink"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Filtered output",

--- a/templates/js-cypress/.actorignore
+++ b/templates/js-cypress/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/js-empty/.actor/dataset_schema.json
+++ b/templates/js-empty/.actor/dataset_schema.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
+    "$comment": "Starter dataset schema. Replace the `value` field below with your Actor's actual output fields, then run `apify push` to upload.",
+    "actorSpecification": 1,
+    "fields": {
+        "title": "Records",
+        "type": "object",
+        "properties": {
+            "value": {
+                "type": "string",
+                "title": "Value"
+            }
+        },
+        "required": [
+            "value"
+        ]
+    },
+    "views": {
+        "overview": {
+            "title": "Overview",
+            "transformation": {
+                "fields": [
+                    "value"
+                ]
+            },
+            "display": {
+                "component": "table",
+                "properties": {
+                    "value": {
+                        "label": "Value",
+                        "format": "text"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/templates/js-empty/.actorignore
+++ b/templates/js-empty/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/js-langchain/.actorignore
+++ b/templates/js-langchain/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/js-langgraph-agent/.actor/dataset_schema.json
+++ b/templates/js-langgraph-agent/.actor/dataset_schema.json
@@ -1,12 +1,32 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "answer": {
+                "type": "string",
+                "title": "Answer"
+            },
+            "question": {
+                "type": "string",
+                "title": "Question"
+            }
+        },
+        "required": [
+            "answer",
+            "question"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["question", "answer"]
+                "fields": [
+                    "question",
+                    "answer"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/js-langgraph-agent/.actorignore
+++ b/templates/js-langgraph-agent/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/js-standby/.actorignore
+++ b/templates/js-standby/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/js-start/.actor/dataset_schema.json
+++ b/templates/js-start/.actor/dataset_schema.json
@@ -1,12 +1,32 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "level": {
+                "type": "string",
+                "title": "Level"
+            },
+            "text": {
+                "type": "string",
+                "title": "Text"
+            }
+        },
+        "required": [
+            "level",
+            "text"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["level", "text"]
+                "fields": [
+                    "level",
+                    "text"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/js-start/.actorignore
+++ b/templates/js-start/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-beautifulsoup/.actor/dataset_schema.json
+++ b/templates/python-beautifulsoup/.actor/dataset_schema.json
@@ -1,12 +1,60 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "h1s": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "H1s"
+            },
+            "h2s": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "H2s"
+            },
+            "h3s": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "H3s"
+            },
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "h1s",
+            "h2s",
+            "h3s",
+            "title",
+            "url"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["title", "url", "h1s", "h2s", "h3s"]
+                "fields": [
+                    "title",
+                    "url",
+                    "h1s",
+                    "h2s",
+                    "h3s"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/python-beautifulsoup/.actorignore
+++ b/templates/python-beautifulsoup/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-crawlee-beautifulsoup/.actor/dataset_schema.json
+++ b/templates/python-crawlee-beautifulsoup/.actor/dataset_schema.json
@@ -1,12 +1,60 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "h1s": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "H1s"
+            },
+            "h2s": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "H2s"
+            },
+            "h3s": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "H3s"
+            },
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "h1s",
+            "h2s",
+            "h3s",
+            "title",
+            "url"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["title", "url", "h1s", "h2s", "h3s"]
+                "fields": [
+                    "title",
+                    "url",
+                    "h1s",
+                    "h2s",
+                    "h3s"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/python-crawlee-beautifulsoup/.actorignore
+++ b/templates/python-crawlee-beautifulsoup/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-crawlee-parsel/.actor/dataset_schema.json
+++ b/templates/python-crawlee-parsel/.actor/dataset_schema.json
@@ -1,12 +1,60 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "h1s": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "H1s"
+            },
+            "h2s": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "H2s"
+            },
+            "h3s": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "H3s"
+            },
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "h1s",
+            "h2s",
+            "h3s",
+            "title",
+            "url"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["title", "url", "h1s", "h2s", "h3s"]
+                "fields": [
+                    "title",
+                    "url",
+                    "h1s",
+                    "h2s",
+                    "h3s"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/python-crawlee-parsel/.actorignore
+++ b/templates/python-crawlee-parsel/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-crawlee-playwright-camoufox/.actor/dataset_schema.json
+++ b/templates/python-crawlee-playwright-camoufox/.actor/dataset_schema.json
@@ -1,12 +1,60 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "h1s": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "H1s"
+            },
+            "h2s": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "H2s"
+            },
+            "h3s": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "H3s"
+            },
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "h1s",
+            "h2s",
+            "h3s",
+            "title",
+            "url"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["title", "url", "h1s", "h2s", "h3s"]
+                "fields": [
+                    "title",
+                    "url",
+                    "h1s",
+                    "h2s",
+                    "h3s"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/python-crawlee-playwright-camoufox/.actorignore
+++ b/templates/python-crawlee-playwright-camoufox/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-crawlee-playwright/.actor/dataset_schema.json
+++ b/templates/python-crawlee-playwright/.actor/dataset_schema.json
@@ -1,12 +1,60 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "h1s": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "H1s"
+            },
+            "h2s": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "H2s"
+            },
+            "h3s": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "H3s"
+            },
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "h1s",
+            "h2s",
+            "h3s",
+            "title",
+            "url"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["title", "url", "h1s", "h2s", "h3s"]
+                "fields": [
+                    "title",
+                    "url",
+                    "h1s",
+                    "h2s",
+                    "h3s"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/python-crawlee-playwright/.actorignore
+++ b/templates/python-crawlee-playwright/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-crewai/.actor/dataset_schema.json
+++ b/templates/python-crewai/.actor/dataset_schema.json
@@ -5,7 +5,10 @@
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["query", "response"]
+                "fields": [
+                    "query",
+                    "response"
+                ]
             },
             "display": {
                 "component": "table",
@@ -21,5 +24,23 @@
                 }
             }
         }
+    },
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "title": "Query"
+            },
+            "response": {
+                "type": "string",
+                "title": "Response"
+            }
+        },
+        "required": [
+            "query",
+            "response"
+        ]
     }
 }

--- a/templates/python-crewai/.actorignore
+++ b/templates/python-crewai/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-empty/.actor/dataset_schema.json
+++ b/templates/python-empty/.actor/dataset_schema.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
+    "$comment": "Starter dataset schema. Replace the `value` field below with your Actor's actual output fields, then run `apify push` to upload.",
+    "actorSpecification": 1,
+    "fields": {
+        "title": "Records",
+        "type": "object",
+        "properties": {
+            "value": {
+                "type": "string",
+                "title": "Value"
+            }
+        },
+        "required": [
+            "value"
+        ]
+    },
+    "views": {
+        "overview": {
+            "title": "Overview",
+            "transformation": {
+                "fields": [
+                    "value"
+                ]
+            },
+            "display": {
+                "component": "table",
+                "properties": {
+                    "value": {
+                        "label": "Value",
+                        "format": "text"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/templates/python-empty/.actorignore
+++ b/templates/python-empty/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-langgraph/.actor/dataset_schema.json
+++ b/templates/python-langgraph/.actor/dataset_schema.json
@@ -5,7 +5,10 @@
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["response", "structured_response"]
+                "fields": [
+                    "response",
+                    "structured_response"
+                ]
             },
             "display": {
                 "component": "table",
@@ -21,5 +24,24 @@
                 }
             }
         }
+    },
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "response": {
+                "type": "string",
+                "title": "Response"
+            },
+            "structured_response": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Structured Response"
+            }
+        },
+        "required": [
+            "response",
+            "structured_response"
+        ]
     }
 }

--- a/templates/python-langgraph/.actorignore
+++ b/templates/python-langgraph/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-llamaindex-agent/.actor/dataset_schema.json
+++ b/templates/python-llamaindex-agent/.actor/dataset_schema.json
@@ -1,12 +1,32 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "answer": {
+                "type": "string",
+                "title": "Answer"
+            },
+            "query": {
+                "type": "string",
+                "title": "Query"
+            }
+        },
+        "required": [
+            "answer",
+            "query"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["query", "answer"]
+                "fields": [
+                    "query",
+                    "answer"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/python-llamaindex-agent/.actorignore
+++ b/templates/python-llamaindex-agent/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-mcp-empty/.actorignore
+++ b/templates/python-mcp-empty/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-mcp-proxy/.actorignore
+++ b/templates/python-mcp-proxy/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-playwright/.actor/dataset_schema.json
+++ b/templates/python-playwright/.actor/dataset_schema.json
@@ -1,12 +1,33 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "title",
+            "url"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["title", "url"]
+                "fields": [
+                    "title",
+                    "url"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/python-playwright/.actorignore
+++ b/templates/python-playwright/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-pydanticai/.actor/dataset_schema.json
+++ b/templates/python-pydanticai/.actor/dataset_schema.json
@@ -1,12 +1,32 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "Joke": {
+                "type": "string",
+                "title": "Joke"
+            },
+            "Topic": {
+                "type": "string",
+                "title": "Topic"
+            }
+        },
+        "required": [
+            "Joke",
+            "Topic"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["Topic", "Joke"]
+                "fields": [
+                    "Topic",
+                    "Joke"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/python-pydanticai/.actorignore
+++ b/templates/python-pydanticai/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-scrapy/.actor/dataset_schema.json
+++ b/templates/python-scrapy/.actor/dataset_schema.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
+    "actorSpecification": 1,
+    "fields": {
+        "title": "Pages",
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "title",
+            "url"
+        ]
+    },
+    "views": {
+        "overview": {
+            "title": "Overview",
+            "transformation": {
+                "fields": [
+                    "title",
+                    "url"
+                ]
+            },
+            "display": {
+                "component": "table",
+                "properties": {
+                    "title": {
+                        "label": "Title",
+                        "format": "text"
+                    },
+                    "url": {
+                        "label": "URL",
+                        "format": "link"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/templates/python-scrapy/.actorignore
+++ b/templates/python-scrapy/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-selenium/.actor/dataset_schema.json
+++ b/templates/python-selenium/.actor/dataset_schema.json
@@ -1,12 +1,33 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "title",
+            "url"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["title", "url"]
+                "fields": [
+                    "title",
+                    "url"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/python-selenium/.actorignore
+++ b/templates/python-selenium/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-smolagents/.actor/dataset_schema.json
+++ b/templates/python-smolagents/.actor/dataset_schema.json
@@ -1,12 +1,26 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "summary": {
+                "type": "string",
+                "title": "Summary"
+            }
+        },
+        "required": [
+            "summary"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["summary"]
+                "fields": [
+                    "summary"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/python-smolagents/.actorignore
+++ b/templates/python-smolagents/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-standby/.actorignore
+++ b/templates/python-standby/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/python-start/.actor/dataset_schema.json
+++ b/templates/python-start/.actor/dataset_schema.json
@@ -1,12 +1,32 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "level": {
+                "type": "string",
+                "title": "Level"
+            },
+            "text": {
+                "type": "string",
+                "title": "Text"
+            }
+        },
+        "required": [
+            "level",
+            "text"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["level", "text"]
+                "fields": [
+                    "level",
+                    "text"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/python-start/.actorignore
+++ b/templates/python-start/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+
+# Bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/ts-beeai-agent/.actor/dataset_schema.json
+++ b/templates/ts-beeai-agent/.actor/dataset_schema.json
@@ -5,7 +5,11 @@
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["query", "response", "structuredResponse"]
+                "fields": [
+                    "query",
+                    "response",
+                    "structuredResponse"
+                ]
             },
             "display": {
                 "component": "table",
@@ -25,5 +29,29 @@
                 }
             }
         }
+    },
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "title": "Query"
+            },
+            "response": {
+                "type": "string",
+                "title": "Response"
+            },
+            "structuredResponse": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Structured Response"
+            }
+        },
+        "required": [
+            "query",
+            "response",
+            "structuredResponse"
+        ]
     }
 }

--- a/templates/ts-beeai-agent/.actorignore
+++ b/templates/ts-beeai-agent/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/ts-bootstrap-cheerio-crawler/.actor/dataset_schema.json
+++ b/templates/ts-bootstrap-cheerio-crawler/.actor/dataset_schema.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
+    "actorSpecification": 1,
+    "fields": {
+        "title": "Pages",
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "title",
+            "url"
+        ]
+    },
+    "views": {
+        "overview": {
+            "title": "Overview",
+            "transformation": {
+                "fields": [
+                    "title",
+                    "url"
+                ]
+            },
+            "display": {
+                "component": "table",
+                "properties": {
+                    "title": {
+                        "label": "Title",
+                        "format": "text"
+                    },
+                    "url": {
+                        "label": "URL",
+                        "format": "link"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/templates/ts-bootstrap-cheerio-crawler/.actorignore
+++ b/templates/ts-bootstrap-cheerio-crawler/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/ts-crawlee-cheerio/.actor/dataset_schema.json
+++ b/templates/ts-crawlee-cheerio/.actor/dataset_schema.json
@@ -1,12 +1,33 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "title",
+            "url"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["title", "url"]
+                "fields": [
+                    "title",
+                    "url"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/ts-crawlee-cheerio/.actorignore
+++ b/templates/ts-crawlee-cheerio/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/ts-crawlee-playwright-camoufox/.actor/dataset_schema.json
+++ b/templates/ts-crawlee-playwright-camoufox/.actor/dataset_schema.json
@@ -1,12 +1,33 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "title",
+            "url"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["title", "url"]
+                "fields": [
+                    "title",
+                    "url"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/ts-crawlee-playwright-camoufox/.actorignore
+++ b/templates/ts-crawlee-playwright-camoufox/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/ts-crawlee-playwright-chrome/.actor/dataset_schema.json
+++ b/templates/ts-crawlee-playwright-chrome/.actor/dataset_schema.json
@@ -1,12 +1,33 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "title",
+            "url"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["title", "url"]
+                "fields": [
+                    "title",
+                    "url"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/ts-crawlee-playwright-chrome/.actorignore
+++ b/templates/ts-crawlee-playwright-chrome/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/ts-crawlee-puppeteer-chrome/.actor/dataset_schema.json
+++ b/templates/ts-crawlee-puppeteer-chrome/.actor/dataset_schema.json
@@ -1,12 +1,33 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "title": "Title"
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "title": "URL"
+            }
+        },
+        "required": [
+            "title",
+            "url"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["title", "url"]
+                "fields": [
+                    "title",
+                    "url"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/ts-crawlee-puppeteer-chrome/.actorignore
+++ b/templates/ts-crawlee-puppeteer-chrome/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/ts-empty/.actor/dataset_schema.json
+++ b/templates/ts-empty/.actor/dataset_schema.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
+    "$comment": "Starter dataset schema. Replace the `value` field below with your Actor's actual output fields, then run `apify push` to upload.",
+    "actorSpecification": 1,
+    "fields": {
+        "title": "Records",
+        "type": "object",
+        "properties": {
+            "value": {
+                "type": "string",
+                "title": "Value"
+            }
+        },
+        "required": [
+            "value"
+        ]
+    },
+    "views": {
+        "overview": {
+            "title": "Overview",
+            "transformation": {
+                "fields": [
+                    "value"
+                ]
+            },
+            "display": {
+                "component": "table",
+                "properties": {
+                    "value": {
+                        "label": "Value",
+                        "format": "text"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/templates/ts-empty/.actorignore
+++ b/templates/ts-empty/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/ts-mastraai/.actor/dataset_schema.json
+++ b/templates/ts-mastraai/.actor/dataset_schema.json
@@ -5,7 +5,10 @@
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["query", "response"]
+                "fields": [
+                    "query",
+                    "response"
+                ]
             },
             "display": {
                 "component": "table",
@@ -21,5 +24,23 @@
                 }
             }
         }
+    },
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "title": "Query"
+            },
+            "response": {
+                "type": "string",
+                "title": "Response"
+            }
+        },
+        "required": [
+            "query",
+            "response"
+        ]
     }
 }

--- a/templates/ts-mastraai/.actorignore
+++ b/templates/ts-mastraai/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/ts-mcp-empty/.actorignore
+++ b/templates/ts-mcp-empty/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/ts-mcp-proxy/.actorignore
+++ b/templates/ts-mcp-proxy/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/ts-playwright-test-runner/.actor/dataset_schema.json
+++ b/templates/ts-playwright-test-runner/.actor/dataset_schema.json
@@ -1,12 +1,66 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Test Report",
+        "type": "object",
+        "properties": {
+            "duration": {
+                "type": "number",
+                "title": "Duration"
+            },
+            "errors": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "Error messages"
+            },
+            "result": {
+                "type": "boolean",
+                "title": "Result"
+            },
+            "runnerName": {
+                "type": "string",
+                "title": "Runner"
+            },
+            "suiteName": {
+                "type": "string",
+                "title": "Test Suite"
+            },
+            "testName": {
+                "type": "string",
+                "title": "Name"
+            },
+            "video": {
+                "type": "string",
+                "format": "uri",
+                "title": "Video recording"
+            }
+        },
+        "required": [
+            "duration",
+            "errors",
+            "result",
+            "runnerName",
+            "suiteName",
+            "testName",
+            "video"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Test Report",
             "transformation": {
-                "fields": ["suiteName", "testName", "runnerName", "result", "errors", "duration", "video"]
+                "fields": [
+                    "suiteName",
+                    "testName",
+                    "runnerName",
+                    "result",
+                    "errors",
+                    "duration",
+                    "video"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/ts-playwright-test-runner/.actorignore
+++ b/templates/ts-playwright-test-runner/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/ts-standby/.actorignore
+++ b/templates/ts-standby/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/ts-start-bun/.actor/dataset_schema.json
+++ b/templates/ts-start-bun/.actor/dataset_schema.json
@@ -1,12 +1,32 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "level": {
+                "type": "string",
+                "title": "Level"
+            },
+            "text": {
+                "type": "string",
+                "title": "Text"
+            }
+        },
+        "required": [
+            "level",
+            "text"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["level", "text"]
+                "fields": [
+                    "level",
+                    "text"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/ts-start-bun/.actorignore
+++ b/templates/ts-start-bun/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/

--- a/templates/ts-start/.actor/dataset_schema.json
+++ b/templates/ts-start/.actor/dataset_schema.json
@@ -1,12 +1,32 @@
 {
     "$schema": "https://apify.com/schemas/v1/dataset.ide.json",
     "actorSpecification": 1,
-    "fields": {},
+    "fields": {
+        "title": "Overview",
+        "type": "object",
+        "properties": {
+            "level": {
+                "type": "string",
+                "title": "Level"
+            },
+            "text": {
+                "type": "string",
+                "title": "Text"
+            }
+        },
+        "required": [
+            "level",
+            "text"
+        ]
+    },
     "views": {
         "overview": {
             "title": "Overview",
             "transformation": {
-                "fields": ["level", "text"]
+                "fields": [
+                    "level",
+                    "text"
+                ]
             },
             "display": {
                 "component": "table",

--- a/templates/ts-start/.actorignore
+++ b/templates/ts-start/.actorignore
@@ -1,0 +1,28 @@
+# .actorignore — files NOT included in `apify push` archives.
+# Mirrors .dockerignore where the rationale is "don't ship to the platform",
+# diverging only where Docker semantics need different contents.
+
+# Build artifacts (Dockerfile rebuilds these inside the image)
+dist/
+build/
+*.tsbuildinfo
+
+# Dependencies (installed by the platform image)
+node_modules/
+
+# Local-development storage
+storage/
+apify_storage/
+crawlee_storage/
+
+# Logs / env / IDE / OS
+*.log
+.env
+.env.*
+.idea/
+.vscode/
+.zed/
+.DS_Store
+
+# Git history
+.git/


### PR DESCRIPTION
## Summary

Library-wide hygiene + observability fix for templates created via `apify create` or fetched via `@apify/actor-templates`. Three coordinated changes:

1. **`.actorignore` added to all 44 templates** so `apify push` excludes build artifacts, dependencies, local storage, and dev/IDE files from the uploaded archive. Currently the entire library ships `.dockerignore` but **zero** templates ship `.actorignore` — every CLI-deploying agent or human pays for the gap.
2. **`.actor/dataset_schema.json` added to 6 data-producing templates** that materially push to a dataset but didn't ship a starter schema (`ts-empty`, `js-empty`, `python-empty`, `ts-bootstrap-cheerio-crawler`, `js-bootstrap-cheerio-crawler`, `python-scrapy`).
3. **`.fields` populated in the 29 existing `dataset_schema.json` files** (they were shipping `"fields": {}` empty alongside a populated `views.overview.transformation.fields` — the schemas were structurally incomplete). Derived `.fields` JSON Schema from each schema's existing field names + display-format hints.

## Scope summary

| Change | File count |
| --- | ---: |
| `.actorignore` added | **44** |
| `.actor/dataset_schema.json` added | **6** |
| `.actor/dataset_schema.json` `.fields` populated | **29** |
| **Total** | **79** |

Total diff: `79 files changed, 2311 insertions(+), 53 deletions(-)`.

## `.actorignore` — language-appropriate contents

Three variants depending on the template's language:

- **Node (TS / JS — 25 templates)**: `dist/`, `build/`, `*.tsbuildinfo`, `node_modules/`, `storage/`, `apify_storage/`, `crawlee_storage/`, `*.log`, `.env*`, IDE/OS files, `.git/`.
- **Python (18 templates)**: `__pycache__/`, `*.pyc`, `*.pyo`, `.venv/`/`venv/`/`env/`, storage dirs, `*.log`, `.env*`, IDE/OS files, `.git/`.
- **Minimal (`cli-start`, shell-only)**: `*.log`, `.env*`, IDE/OS files, `.git/`.

## Templates intentionally NOT given a `dataset_schema.json`

Audited each template's main code file for `Actor.pushData` / `Actor.push_data` / equivalent. The following 9 templates do **not** push to a dataset and intentionally do not ship one:

- `cli-start` — shell-only template; no data path.
- `js-langchain` — writes only to the key-value store via `Actor.setValue('OUTPUT', res)`. No `pushData` calls anywhere. (Already ships `key_value_store_schema.json` and `output_schema.json` — which is correct for its pattern.)
- `ts-standby`, `js-standby`, `python-standby` — HTTP servers; request/response, no dataset writes.
- `ts-mcp-empty`, `ts-mcp-proxy`, `python-mcp-empty`, `python-mcp-proxy` — MCP servers; serve endpoints, no dataset writes.

Shipping a dataset_schema for a non-dataset-writing template would imply a contract the template doesn't use and would mislead users about output location.

## `.fields` population approach

For the 29 existing `dataset_schema.json` files with empty `.fields`, derived `fields.properties` from the schema's existing `views.overview.transformation.fields` list, with types mapped from the corresponding `views.overview.display.properties.<name>.format`:

| Display format | Derived JSON Schema |
| --- | --- |
| `link`, `image` | `{ "type": "string", "format": "uri" }` |
| `array` | `{ "type": "array", "items": { "type": "string" } }` |
| `number` | `{ "type": "number" }` |
| `boolean` | `{ "type": "boolean" }` |
| `date` | `{ "type": "string", "format": "date-time" }` |
| `object` | `{ "type": "object", "additionalProperties": true }` |
| `text` / default | `{ "type": "string" }` |

Each populated schema also gains a `"required": [...]` listing all derived field names. The structure remains internally consistent with what the existing `views` already declared.

## What this fixes downstream

Closes the following items from the `chocholous/apify-evals` finding tracker:

- **F8 / F27** — agents and humans ship bloated archives (no `.actorignore`).
- **F29** — agents ship `dist/` alongside `src/` because the Dockerfile doesn't get a chance to rebuild from scratch.
- **F26** — `ts-empty` (and other empty starters) ship no `dataset_schema.json`, triggering T1 soft-warns on every template-using agent.
- **F3** — `.fields` empty soft-warn fires on every template-derived Actor.

## Out of scope (separate PRs)

- The 16 JS/TS templates where `name` is fundamentally different from `id` (e.g. `js-empty` / `project_empty`, `js-start` / `getting_started_node`) warrant a coordinated rename + `apify-cli` alias support to maintain backward compatibility. Tracked separately.
- The `@apify/json_schemas` `actor.schema.json` `.version` regex being looser than the platform's `MAJOR_MINOR_VERSION_REGEX` is an `apify-shared-js` issue, not a templates one.

## Test plan

- [ ] CI green on existing tests
- [ ] Spot-check `apify create -t ts-empty` produces a scaffold that includes both `.actorignore` and `.actor/dataset_schema.json` after `dist/templates/ts-empty.zip` is regenerated by CI
- [ ] Spot-check `apify push` archive size shrinks for a template scaffold (no `node_modules/` or `storage/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)