### PR TITLE
fix: empty templates ship input_schema.json and reference it from actor.json

### DIFF
--- a/agent-bases/js.AGENTS.md
+++ b/agent-bases/js.AGENTS.md
@@ -26,6 +26,7 @@ Important: Before you begin, fill in the `generatedBy` property in the meta sect
 - implement retry strategies with exponential backoff for failed requests
 - use proper concurrency settings (HTTP: 10-50, Browser: 1-5)
 - set sensible defaults in `.actor/input_schema.json` for all optional fields
+- explicitly reference the input schema from `.actor/actor.json` by adding `"input": "./input_schema.json"` — do not rely on auto-discovery, which is deprecated
 - set up output schema in `.actor/output_schema.json`
 - clean and validate data before pushing to dataset
 - use semantic CSS selectors and fallback strategies for missing elements
@@ -187,8 +188,8 @@ Ask first:
 ## Project Structure
 
 .actor/
-├── actor.json # Actor config: name, version, env vars, runtime settings
-├── input_schema.json # Input validation & Console form definition
+├── actor.json # Actor config: name, version, env vars, runtime settings, input schema reference
+├── input_schema.json # Input validation & Console form definition (referenced from actor.json via "input")
 └── output_schema.json # Specifies where an Actor stores its output
 src/
 └── main.js # Actor entry point and orchestrator

--- a/agent-bases/python.AGENTS.md
+++ b/agent-bases/python.AGENTS.md
@@ -26,6 +26,7 @@ Important: Before you begin, fill in the `generatedBy` property in the meta sect
 - implement retry strategies with exponential backoff for failed requests
 - use proper concurrency settings (HTTP: 10-50, Browser: 1-5)
 - set sensible defaults in `.actor/input_schema.json` for all optional fields
+- explicitly reference the input schema from `.actor/actor.json` by adding `"input": "./input_schema.json"` — do not rely on auto-discovery, which is deprecated
 - set up output schema in `.actor/output_schema.json`
 - clean and validate data before pushing to dataset
 - use semantic CSS selectors and fallback strategies for missing elements
@@ -189,8 +190,8 @@ Ask first:
 ## Project Structure
 
 .actor/
-├── actor.json # Actor config: name, version, env vars, runtime settings
-├── input_schema.json # Input validation & Console form definition
+├── actor.json # Actor config: name, version, env vars, runtime settings, input schema reference
+├── input_schema.json # Input validation & Console form definition (referenced from actor.json via "input")
 └── output_schema.json # Specifies where an Actor stores its output
 src/
 └── main.js # Actor entry point and orchestrator

--- a/agent-bases/ts.AGENTS.md
+++ b/agent-bases/ts.AGENTS.md
@@ -26,6 +26,7 @@ Important: Before you begin, fill in the `generatedBy` property in the meta sect
 - implement retry strategies with exponential backoff for failed requests
 - use proper concurrency settings (HTTP: 10-50, Browser: 1-5)
 - set sensible defaults in `.actor/input_schema.json` for all optional fields
+- explicitly reference the input schema from `.actor/actor.json` by adding `"input": "./input_schema.json"` — do not rely on auto-discovery, which is deprecated
 - set up output schema in `.actor/output_schema.json`
 - clean and validate data before pushing to dataset
 - use semantic CSS selectors and fallback strategies for missing elements
@@ -190,8 +191,8 @@ Ask first:
 ## Project Structure
 
 .actor/
-├── actor.json # Actor config: name, version, env vars, runtime settings
-├── input_schema.json # Input validation & Console form definition
+├── actor.json # Actor config: name, version, env vars, runtime settings, input schema reference
+├── input_schema.json # Input validation & Console form definition (referenced from actor.json via "input")
 └── output_schema.json # Specifies where an Actor stores its output
 src/
 └── main.js # Actor entry point and orchestrator

--- a/templates/js-empty/.actor/actor.json
+++ b/templates/js-empty/.actor/actor.json
@@ -10,5 +10,6 @@
         "templateId": "js-empty",
         "generatedBy": "<FILL-IN-MODEL>"
     },
+    "input": "./input_schema.json",
     "dockerfile": "../Dockerfile"
 }

--- a/templates/js-empty/.actor/input_schema.json
+++ b/templates/js-empty/.actor/input_schema.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://apify.com/schemas/v1/input.ide.json",
+    "title": "Actor Input",
+    "type": "object",
+    "schemaVersion": 1,
+    "properties": {
+        "example": {
+            "title": "Example Field",
+            "type": "string",
+            "description": "Replace this with your actual input fields.",
+            "editor": "textfield"
+        }
+    },
+    "required": []
+}

--- a/templates/python-empty/.actor/actor.json
+++ b/templates/python-empty/.actor/actor.json
@@ -10,5 +10,6 @@
         "templateId": "python-empty",
         "generatedBy": "<FILL-IN-MODEL>"
     },
+    "input": "./input_schema.json",
     "dockerfile": "../Dockerfile"
 }

--- a/templates/python-empty/.actor/input_schema.json
+++ b/templates/python-empty/.actor/input_schema.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://apify.com/schemas/v1/input.ide.json",
+    "title": "Actor Input",
+    "type": "object",
+    "schemaVersion": 1,
+    "properties": {
+        "example": {
+            "title": "Example Field",
+            "type": "string",
+            "description": "Replace this with your actual input fields.",
+            "editor": "textfield"
+        }
+    },
+    "required": []
+}

--- a/templates/ts-empty/.actor/actor.json
+++ b/templates/ts-empty/.actor/actor.json
@@ -10,5 +10,6 @@
         "templateId": "ts-empty",
         "generatedBy": "<FILL-IN-MODEL>"
     },
+    "input": "./input_schema.json",
     "dockerfile": "../Dockerfile"
 }

--- a/templates/ts-empty/.actor/input_schema.json
+++ b/templates/ts-empty/.actor/input_schema.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://apify.com/schemas/v1/input.ide.json",
+    "title": "Actor Input",
+    "type": "object",
+    "schemaVersion": 1,
+    "properties": {
+        "example": {
+            "title": "Example Field",
+            "type": "string",
+            "description": "Replace this with your actual input fields.",
+            "editor": "textfield"
+        }
+    },
+    "required": []
+}


### PR DESCRIPTION
## Summary

Empty templates (`ts-empty`, `js-empty`, `python-empty`) were the only common scaffolding starting points that did not ship a `.actor/input_schema.json` — and their `actor.json` didn't carry a `.input` reference either. Agents extrapolating from these templates produce Actors that rely on the platform's deprecated auto-discovery fallback (see `apify-docs` input_schema/specification.md line 21).

This PR brings them into line with the `start` templates (which already ship both files + the linkage) and updates the shared `agent-bases/{ts,js,python}.AGENTS.md` files so the explicit-reference pattern is taught in the docs that propagate to every per-template AGENTS.md.

## Scope

| Change | Files |
| --- | --- |
| New `.actor/input_schema.json` starter file | `templates/{ts,js,python}-empty/.actor/input_schema.json` (3 new) |
| `.actor/actor.json` gains `"input": "./input_schema.json"` | `templates/{ts,js,python}-empty/.actor/actor.json` (3 modified) |
| `agent-bases/{ts,js,python}.AGENTS.md` — Do-list bullet + project-tree annotation | 3 modified |
| **Total** | **9 files** (3 new, 6 modified) |

Per the README: `agent-bases/<lang>.AGENTS.md` files propagate to every per-template AGENTS.md via CI, so the 3 base edits lift every template.

## Starter `input_schema.json` content

Each empty template ships:

```json
{
    "$schema": "https://apify.com/schemas/v1/input.ide.json",
    "title": "Actor Input",
    "type": "object",
    "schemaVersion": 1,
    "properties": {
        "example": {
            "title": "Example Field",
            "type": "string",
            "description": "Replace this with your actual input fields.",
            "editor": "textfield"
        }
    },
    "required": []
}
```

Single placeholder field, no required fields, lowest-friction for agents/users to replace with the real schema.

## AGENTS.md changes (applied to all 3 shared bases)

```diff
 - set sensible defaults in `.actor/input_schema.json` for all optional fields
+- explicitly reference the input schema from `.actor/actor.json` by adding `"input": "./input_schema.json"` — do not rely on auto-discovery, which is deprecated
```

Plus the project-structure tree now reads:
```
.actor/
├── actor.json # Actor config: name, version, env vars, runtime settings, input schema reference
├── input_schema.json # Input validation & Console form definition (referenced from actor.json via "input")
└── output_schema.json # Specifies where an Actor stores its output
```

## Test plan

- [ ] CI green (template archives rebuild via the `dist/templates/*.zip` action)
- [ ] `apify create -t ts-empty` produces a scaffold that includes both `.actor/input_schema.json` AND `.input` reference in `actor.json`
- [ ] Same for `js-empty` and `python-empty`
- [ ] Per-template `AGENTS.md` files are auto-updated by the CI propagation workflow

## Refs

- chocholous/apify-evals F40 (the gap this fixes)
- Companion docs PR: apify/apify-docs#2662 (academy tutorial + actor.json reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)