### PR TITLE
build: move repo to prettier 3.9.x (fix template format:check drift)

### DIFF
--- a/agent-bases/js.AGENTS.md
+++ b/agent-bases/js.AGENTS.md
@@ -220,9 +220,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -286,9 +284,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/agent-bases/python.AGENTS.md
+++ b/agent-bases/python.AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/agent-bases/ts.AGENTS.md
+++ b/agent-bases/ts.AGENTS.md
@@ -223,9 +223,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -289,9 +287,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "json5": "^2.2.3",
         "mustache": "^4.2.0",
         "playwright": "1.60.0",
-        "prettier": "^3.7.4",
+        "prettier": "^3.9.1",
         "puppeteer": "24.43.1",
         "semver": "^7.7.2",
         "typescript": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,8 +253,8 @@ importers:
         specifier: 1.60.0
         version: 1.60.0
       prettier:
-        specifier: ^3.7.4
-        version: 3.8.3
+        specifier: ^3.9.1
+        version: 3.9.1
       puppeteer:
         specifier: 24.43.1
         version: 24.43.1(typescript@6.0.3)
@@ -2887,8 +2887,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+  prettier@3.9.1:
+    resolution: {integrity: sha512-ppiDo2CSwexck1eyZUwJHg/N3nf1+6IRCv7W/VJ5vaLnVCmB7+3CdRfMwoCHBBX6xTrREDTksZ4OZl5SSf4zXA==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -6781,7 +6781,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.8.3: {}
+  prettier@3.9.1: {}
 
   pretty-format@30.4.1:
     dependencies:

--- a/templates/js-bootstrap-cheerio-crawler/AGENTS.md
+++ b/templates/js-bootstrap-cheerio-crawler/AGENTS.md
@@ -220,9 +220,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -286,9 +284,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/js-crawlee-cheerio/AGENTS.md
+++ b/templates/js-crawlee-cheerio/AGENTS.md
@@ -220,9 +220,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -286,9 +284,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/js-crawlee-playwright-camoufox/AGENTS.md
+++ b/templates/js-crawlee-playwright-camoufox/AGENTS.md
@@ -220,9 +220,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -286,9 +284,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/js-crawlee-playwright-chrome/AGENTS.md
+++ b/templates/js-crawlee-playwright-chrome/AGENTS.md
@@ -220,9 +220,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -286,9 +284,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/js-crawlee-puppeteer-chrome/AGENTS.md
+++ b/templates/js-crawlee-puppeteer-chrome/AGENTS.md
@@ -220,9 +220,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -286,9 +284,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/js-cypress/AGENTS.md
+++ b/templates/js-cypress/AGENTS.md
@@ -220,9 +220,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -286,9 +284,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/js-empty/AGENTS.md
+++ b/templates/js-empty/AGENTS.md
@@ -220,9 +220,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -286,9 +284,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/js-langchain/AGENTS.md
+++ b/templates/js-langchain/AGENTS.md
@@ -220,9 +220,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -286,9 +284,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/js-langgraph-agent/AGENTS.md
+++ b/templates/js-langgraph-agent/AGENTS.md
@@ -220,9 +220,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -286,9 +284,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/js-standby/AGENTS.md
+++ b/templates/js-standby/AGENTS.md
@@ -220,9 +220,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -286,9 +284,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/js-start/AGENTS.md
+++ b/templates/js-start/AGENTS.md
@@ -220,9 +220,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -286,9 +284,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-beautifulsoup/AGENTS.md
+++ b/templates/python-beautifulsoup/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-crawlee-beautifulsoup/AGENTS.md
+++ b/templates/python-crawlee-beautifulsoup/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-crawlee-parsel/AGENTS.md
+++ b/templates/python-crawlee-parsel/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-crawlee-playwright-camoufox/AGENTS.md
+++ b/templates/python-crawlee-playwright-camoufox/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-crawlee-playwright/AGENTS.md
+++ b/templates/python-crawlee-playwright/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-crewai/AGENTS.md
+++ b/templates/python-crewai/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-empty/AGENTS.md
+++ b/templates/python-empty/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-langgraph/AGENTS.md
+++ b/templates/python-langgraph/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-llamaindex-agent/AGENTS.md
+++ b/templates/python-llamaindex-agent/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-mcp-empty/AGENTS.md
+++ b/templates/python-mcp-empty/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-mcp-proxy/AGENTS.md
+++ b/templates/python-mcp-proxy/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-playwright/AGENTS.md
+++ b/templates/python-playwright/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-pydanticai/AGENTS.md
+++ b/templates/python-pydanticai/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-scrapy/AGENTS.md
+++ b/templates/python-scrapy/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-selenium/AGENTS.md
+++ b/templates/python-selenium/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-smolagents/AGENTS.md
+++ b/templates/python-smolagents/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-standby/AGENTS.md
+++ b/templates/python-standby/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/python-start/AGENTS.md
+++ b/templates/python-start/AGENTS.md
@@ -222,9 +222,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -288,9 +286,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/ts-beeai-agent/AGENTS.md
+++ b/templates/ts-beeai-agent/AGENTS.md
@@ -223,9 +223,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -289,9 +287,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/ts-bootstrap-cheerio-crawler/AGENTS.md
+++ b/templates/ts-bootstrap-cheerio-crawler/AGENTS.md
@@ -223,9 +223,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -289,9 +287,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/ts-crawlee-cheerio/AGENTS.md
+++ b/templates/ts-crawlee-cheerio/AGENTS.md
@@ -223,9 +223,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -289,9 +287,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/ts-crawlee-playwright-camoufox/AGENTS.md
+++ b/templates/ts-crawlee-playwright-camoufox/AGENTS.md
@@ -223,9 +223,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -289,9 +287,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/ts-crawlee-playwright-chrome/AGENTS.md
+++ b/templates/ts-crawlee-playwright-chrome/AGENTS.md
@@ -223,9 +223,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -289,9 +287,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/ts-crawlee-puppeteer-chrome/AGENTS.md
+++ b/templates/ts-crawlee-puppeteer-chrome/AGENTS.md
@@ -223,9 +223,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -289,9 +287,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/ts-empty/AGENTS.md
+++ b/templates/ts-empty/AGENTS.md
@@ -223,9 +223,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -289,9 +287,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/ts-mastraai/AGENTS.md
+++ b/templates/ts-mastraai/AGENTS.md
@@ -223,9 +223,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -289,9 +287,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/ts-mcp-empty/AGENTS.md
+++ b/templates/ts-mcp-empty/AGENTS.md
@@ -223,9 +223,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -289,9 +287,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/ts-mcp-proxy/AGENTS.md
+++ b/templates/ts-mcp-proxy/AGENTS.md
@@ -223,9 +223,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -289,9 +287,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/ts-playwright-test-runner/AGENTS.md
+++ b/templates/ts-playwright-test-runner/AGENTS.md
@@ -223,9 +223,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -289,9 +287,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/ts-standby/AGENTS.md
+++ b/templates/ts-standby/AGENTS.md
@@ -223,9 +223,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -289,9 +287,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/ts-start-bun/AGENTS.md
+++ b/templates/ts-start-bun/AGENTS.md
@@ -223,9 +223,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -289,9 +287,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 

--- a/templates/ts-start/AGENTS.md
+++ b/templates/ts-start/AGENTS.md
@@ -223,9 +223,7 @@ The input schema defines the input parameters for an Actor. It's a JSON object c
     "title": "<INPUT-SCHEMA-TITLE>",
     "type": "object",
     "schemaVersion": 1,
-    "properties": {
-        /* define input fields here */
-    },
+    "properties": {/* define input fields here */},
     "required": []
 }
 ```
@@ -289,9 +287,7 @@ The Actor output schema builds upon the schemas for the dataset and key-value st
 {
     "actorOutputSchemaVersion": 1,
     "title": "<OUTPUT-SCHEMA-TITLE>",
-    "properties": {
-        /* define your outputs here */
-    }
+    "properties": {/* define your outputs here */}
 }
 ```
 


### PR DESCRIPTION
## Root cause: prettier version drift between root and templates

The per-template `format:check` (run in CI by **Test Node.js templates** / **Test LLM AI Node.js templates**) started failing on every PR run on/after **2026-06-27** (e.g. [#824](https://github.com/apify/actor-templates/pull/824)) due to a **version mismatch**:

| | prettier range | lockfile | version it installs |
|---|---|---|---|
| **repo root** | `^3.7.4` | ✅ `pnpm-lock.yaml` | **3.8.3** (frozen) |
| **each template** | `^3.5.3` | ❌ none | **3.9.x** (fresh `npm install` floats to newest) |

**Prettier 3.9.0** (2026-06-27) reformats the comment-only objects in the `AGENTS.md` input/output schema snippets. So the templates' 3.9.x flagged files that the root's pinned 3.8.3 considers correctly formatted.

## Fix: put the whole repo on prettier 3.9.x
Bump the root prettier and reformat, so the root and the templates' floating installs agree.

## Notes
- Root lands on **3.9.1**, not 3.9.3 — the repo's `minimumReleaseAge: 1440` (24h) blocks 3.9.2/3.9.3 (released today). The templates' npm install has no such policy and floats to 3.9.3; 3.9.1 and 3.9.3 produce identical output for these files (verified). They'll converge once 3.9.3 is >24h old.

- The templates still float (`^`, no lockfile), so a *future* prettier release that changes formatting can re-introduce this for the templates (the root is shielded by its lockfile until bumped deliberately).