### PR TITLE
chore: set @l2ysho and @DaveHanns as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @l2ysho @DaveHanns


### PR DESCRIPTION
## What

Adds a `.github/CODEOWNERS` setting **@l2ysho** and **@DaveHanns** as the default code owners (actor-templates had no CODEOWNERS file before):

```diff
+* @l2ysho @DaveHanns
```

## Why

So @l2ysho and @DaveHanns are auto-requested for review on changes across the repo. Mirrors apify/apify-cli#1208.

## Note

Both users need **write access** to this repository for the CODEOWNERS entry to take effect — otherwise GitHub silently ignores it.