### PR TITLE
fix(ts-templates): allow esbuild + unrs-resolver install scripts for tsx

### DIFF
--- a/templates/ts-beeai-agent/package.json
+++ b/templates/ts-beeai-agent/package.json
@@ -25,6 +25,10 @@
         "typescript-eslint": "^8.60.0",
         "vitest": "^4.1.7"
     },
+    "trustedDependencies": [
+        "esbuild",
+        "unrs-resolver"
+    ],
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",

--- a/templates/ts-bootstrap-cheerio-crawler/package.json
+++ b/templates/ts-bootstrap-cheerio-crawler/package.json
@@ -23,6 +23,10 @@
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },
+    "trustedDependencies": [
+        "esbuild",
+        "unrs-resolver"
+    ],
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",

--- a/templates/ts-crawlee-cheerio/package.json
+++ b/templates/ts-crawlee-cheerio/package.json
@@ -23,6 +23,10 @@
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },
+    "trustedDependencies": [
+        "esbuild",
+        "unrs-resolver"
+    ],
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",

--- a/templates/ts-crawlee-playwright-camoufox/package.json
+++ b/templates/ts-crawlee-playwright-camoufox/package.json
@@ -25,6 +25,10 @@
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },
+    "trustedDependencies": [
+        "esbuild",
+        "unrs-resolver"
+    ],
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",

--- a/templates/ts-crawlee-playwright-chrome/package.json
+++ b/templates/ts-crawlee-playwright-chrome/package.json
@@ -24,6 +24,10 @@
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },
+    "trustedDependencies": [
+        "esbuild",
+        "unrs-resolver"
+    ],
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",

--- a/templates/ts-crawlee-puppeteer-chrome/package.json
+++ b/templates/ts-crawlee-puppeteer-chrome/package.json
@@ -24,6 +24,10 @@
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },
+    "trustedDependencies": [
+        "esbuild",
+        "unrs-resolver"
+    ],
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",

--- a/templates/ts-empty/package.json
+++ b/templates/ts-empty/package.json
@@ -23,6 +23,10 @@
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },
+    "trustedDependencies": [
+        "esbuild",
+        "unrs-resolver"
+    ],
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",

--- a/templates/ts-mastraai/package.json
+++ b/templates/ts-mastraai/package.json
@@ -26,6 +26,10 @@
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },
+    "trustedDependencies": [
+        "esbuild",
+        "unrs-resolver"
+    ],
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",

--- a/templates/ts-mcp-empty/package.json
+++ b/templates/ts-mcp-empty/package.json
@@ -28,6 +28,10 @@
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },
+    "trustedDependencies": [
+        "esbuild",
+        "unrs-resolver"
+    ],
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",

--- a/templates/ts-mcp-proxy/package.json
+++ b/templates/ts-mcp-proxy/package.json
@@ -30,6 +30,10 @@
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },
+    "trustedDependencies": [
+        "esbuild",
+        "unrs-resolver"
+    ],
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",

--- a/templates/ts-playwright-test-runner/package.json
+++ b/templates/ts-playwright-test-runner/package.json
@@ -3,6 +3,10 @@
     "version": "1.0.0",
     "description": "",
     "type": "module",
+    "trustedDependencies": [
+        "esbuild",
+        "unrs-resolver"
+    ],
     "scripts": {
         "start": "npm run start:dev",
         "start:dev": "tsx src/main.ts",

--- a/templates/ts-standby/package.json
+++ b/templates/ts-standby/package.json
@@ -22,6 +22,10 @@
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },
+    "trustedDependencies": [
+        "esbuild",
+        "unrs-resolver"
+    ],
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",

--- a/templates/ts-start-bun/package.json
+++ b/templates/ts-start-bun/package.json
@@ -24,6 +24,10 @@
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },
+    "trustedDependencies": [
+        "esbuild",
+        "unrs-resolver"
+    ],
     "scripts": {
         "start": "bun src/main.ts",
         "test": "vitest run"

--- a/templates/ts-start/package.json
+++ b/templates/ts-start/package.json
@@ -24,6 +24,10 @@
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },
+    "trustedDependencies": [
+        "esbuild",
+        "unrs-resolver"
+    ],
     "scripts": {
         "start": "npm run start:dev",
         "start:prod": "node dist/main.js",


### PR DESCRIPTION
## Summary

npm 11 introduced an allowlist for dependency lifecycle scripts. Freshly scaffolded TypeScript templates run `tsx src/main.ts` (via `npm start` / `apify run`), and `tsx` depends transitively on `esbuild`, whose native binary is fetched by a `postinstall` script. Under npm 11+ that script is silently skipped, so `tsx` fails at runtime.

This PR adds a two-entry `trustedDependencies` allowlist to every `ts-*` template so `esbuild` and `unrs-resolver` are permitted to run their install scripts.

## Reproduction (before this PR)

```
$ apify create my-actor -t ts-empty
$ cd my-actor
$ npm install
...
npm warn allow-scripts   esbuild@0.28.1 (postinstall: node install.js)
npm warn allow-scripts   unrs-resolver@1.12.2 (postinstall: node postinstall.js)
...
$ npm start
> tsx src/main.ts
node:internal/modules/esm/resolve:... Cannot find package 'esbuild/bin/esbuild' ...
```

The obvious workaround (`npm approve-scripts esbuild unrs-resolver`) does **not** work on a fresh install — the packages have not yet been installed, so approve-scripts errors out:

```
npm error code ENOMATCH
npm error No installed packages match: esbuild, unrs-resolver
```

That produces a chicken-and-egg situation where the user has to run `npm install` twice (once with `--ignore-scripts=false` after manual approval, etc.), which is friction they should not have to discover.

## Fix

Add to each `templates/ts-*/package.json`:

```json
"trustedDependencies": [
    "esbuild",
    "unrs-resolver"
]
```

This is npm 11's opt-in mechanism for pre-approving lifecycle scripts of specific packages. It is inert on older npm versions (which already run all install scripts by default), so it is safe for the templates' `engines.node: >=18` support range.

Applied to all 14 templates that ship `tsx`:

- ts-beeai-agent
- ts-bootstrap-cheerio-crawler
- ts-crawlee-cheerio
- ts-crawlee-playwright-camoufox
- ts-crawlee-playwright-chrome
- ts-crawlee-puppeteer-chrome
- ts-empty
- ts-mastraai
- ts-mcp-empty
- ts-mcp-proxy
- ts-playwright-test-runner
- ts-standby
- ts-start
- ts-start-bun

## Test plan

- [ ] `apify create tmp -t ts-empty && cd tmp && npm install` completes without any `npm warn allow-scripts` lines for `esbuild` / `unrs-resolver`.
- [ ] `node_modules/esbuild/bin/esbuild --version` works.
- [ ] `apify run` (or `npm start`) launches without `tsx` erroring on missing esbuild binary.
- [ ] Verify no regression on npm 10 (`trustedDependencies` is ignored there).

## Follow-up (not in this PR)

Once base images track Node 22+ / 24+, `start:dev` could migrate from `tsx` to `node --experimental-strip-types src/main.ts` and drop the `tsx` + `esbuild` dependency chain entirely.

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._