### PR TITLE
fix(ts-templates): move tsx and typescript to dependencies

### DIFF
--- a/templates/ts-beeai-agent/package.json
+++ b/templates/ts-beeai-agent/package.json
@@ -10,7 +10,9 @@
         "@ai-sdk/openai": "3.0.63",
         "apify": "^3.7.2",
         "beeai-framework": "^0.1.29",
-        "zod": "^3.25.76"
+        "zod": "^3.25.76",
+        "tsx": "^4.22.3",
+        "typescript": "^6.0.3"
     },
     "devDependencies": {
         "@apify/eslint-config": "^2.0.6",
@@ -20,8 +22,6 @@
         "eslint-config-prettier": "^10.1.8",
         "globals": "^17.6.0",
         "prettier": "^3.8.3",
-        "tsx": "^4.22.3",
-        "typescript": "^6.0.3",
         "typescript-eslint": "^8.60.0",
         "vitest": "^4.1.7"
     },

--- a/templates/ts-bootstrap-cheerio-crawler/package.json
+++ b/templates/ts-bootstrap-cheerio-crawler/package.json
@@ -8,7 +8,9 @@
     },
     "dependencies": {
         "apify": "^3.7.0",
-        "@crawlee/cheerio": "^3.15.3"
+        "@crawlee/cheerio": "^3.15.3",
+        "tsx": "^4.20.3",
+        "typescript": "^6.0.0"
     },
     "devDependencies": {
         "@apify/eslint-config": "^2.0.0",
@@ -18,8 +20,6 @@
         "eslint-config-prettier": "^10.1.5",
         "globals": "^17.0.0",
         "prettier": "^3.5.3",
-        "tsx": "^4.20.3",
-        "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },

--- a/templates/ts-crawlee-cheerio/package.json
+++ b/templates/ts-crawlee-cheerio/package.json
@@ -8,7 +8,9 @@
     },
     "dependencies": {
         "apify": "^3.7.0",
-        "@crawlee/cheerio": "^3.15.3"
+        "@crawlee/cheerio": "^3.15.3",
+        "tsx": "^4.20.3",
+        "typescript": "^6.0.0"
     },
     "devDependencies": {
         "@apify/eslint-config": "^2.0.0",
@@ -18,8 +20,6 @@
         "eslint-config-prettier": "^10.1.5",
         "globals": "^17.0.0",
         "prettier": "^3.5.3",
-        "tsx": "^4.20.3",
-        "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },

--- a/templates/ts-crawlee-playwright-camoufox/package.json
+++ b/templates/ts-crawlee-playwright-camoufox/package.json
@@ -10,7 +10,9 @@
         "apify": "^3.7.0",
         "camoufox-js": "^0.9.0",
         "@crawlee/playwright": "^3.15.3",
-        "playwright": "1.60.0"
+        "playwright": "1.60.0",
+        "tsx": "^4.20.3",
+        "typescript": "^6.0.0"
     },
     "devDependencies": {
         "@apify/eslint-config": "^2.0.0",
@@ -20,8 +22,6 @@
         "eslint-config-prettier": "^10.1.5",
         "globals": "^17.0.0",
         "prettier": "^3.5.3",
-        "tsx": "^4.20.3",
-        "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },

--- a/templates/ts-crawlee-playwright-chrome/package.json
+++ b/templates/ts-crawlee-playwright-chrome/package.json
@@ -9,7 +9,9 @@
     "dependencies": {
         "apify": "^3.7.0",
         "@crawlee/playwright": "^3.15.3",
-        "playwright": "1.60.0"
+        "playwright": "1.60.0",
+        "tsx": "^4.20.3",
+        "typescript": "^6.0.0"
     },
     "devDependencies": {
         "@apify/eslint-config": "^2.0.0",
@@ -19,8 +21,6 @@
         "eslint-config-prettier": "^10.1.5",
         "globals": "^17.0.0",
         "prettier": "^3.5.3",
-        "tsx": "^4.20.3",
-        "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },

--- a/templates/ts-crawlee-puppeteer-chrome/package.json
+++ b/templates/ts-crawlee-puppeteer-chrome/package.json
@@ -9,7 +9,9 @@
     "dependencies": {
         "apify": "^3.7.0",
         "@crawlee/puppeteer": "^3.15.3",
-        "puppeteer": "24.43.1"
+        "puppeteer": "24.43.1",
+        "tsx": "^4.20.3",
+        "typescript": "^6.0.0"
     },
     "devDependencies": {
         "@apify/eslint-config": "^2.0.0",
@@ -19,8 +21,6 @@
         "eslint-config-prettier": "^10.1.5",
         "globals": "^17.0.0",
         "prettier": "^3.5.3",
-        "tsx": "^4.20.3",
-        "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },

--- a/templates/ts-empty/package.json
+++ b/templates/ts-empty/package.json
@@ -8,7 +8,9 @@
     },
     "dependencies": {
         "apify": "^3.7.0",
-        "@crawlee/cheerio": "^3.15.3"
+        "@crawlee/cheerio": "^3.15.3",
+        "tsx": "^4.20.3",
+        "typescript": "^6.0.0"
     },
     "devDependencies": {
         "@apify/eslint-config": "^2.0.0",
@@ -18,8 +20,6 @@
         "eslint-config-prettier": "^10.1.5",
         "globals": "^17.0.0",
         "prettier": "^3.5.3",
-        "tsx": "^4.20.3",
-        "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },

--- a/templates/ts-mastraai/package.json
+++ b/templates/ts-mastraai/package.json
@@ -11,7 +11,9 @@
         "@mastra/core": "^1.1.0",
         "apify": "^3.7.0",
         "mastra": "^1.1.0",
-        "zod": "^4.3.6"
+        "zod": "^4.3.6",
+        "tsx": "^4.21.0",
+        "typescript": "^6.0.0"
     },
     "devDependencies": {
         "@apify/eslint-config": "^2.0.0",
@@ -21,8 +23,6 @@
         "eslint-config-prettier": "^10.1.8",
         "globals": "^17.2.0",
         "prettier": "^3.8.1",
-        "tsx": "^4.21.0",
-        "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },

--- a/templates/ts-mcp-empty/package.json
+++ b/templates/ts-mcp-empty/package.json
@@ -11,7 +11,9 @@
         "express": "^5.1.0",
         "cors": "^2.8.5",
         "zod": "^3.25.76",
-        "apify": "^3.7.0"
+        "apify": "^3.7.0",
+        "tsx": "^4.20.3",
+        "typescript": "^6.0.0"
     },
     "devDependencies": {
         "@apify/eslint-config": "^2.0.0",
@@ -23,8 +25,6 @@
         "eslint-config-prettier": "^10.1.5",
         "globals": "^17.0.0",
         "prettier": "^3.5.3",
-        "tsx": "^4.20.3",
-        "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },

--- a/templates/ts-mcp-proxy/package.json
+++ b/templates/ts-mcp-proxy/package.json
@@ -13,7 +13,9 @@
         "apify": "^3.7.0",
         "body-parser": "^2.2.0",
         "express": "^5.1.0",
-        "zod": "^3.25.76"
+        "zod": "^3.25.76",
+        "tsx": "^4.20.3",
+        "typescript": "^6.0.0"
     },
     "devDependencies": {
         "@apify/eslint-config": "^2.0.0",
@@ -25,8 +27,6 @@
         "eslint-config-prettier": "^10.1.5",
         "globals": "^17.0.0",
         "prettier": "^3.5.3",
-        "tsx": "^4.20.3",
-        "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },

--- a/templates/ts-standby/package.json
+++ b/templates/ts-standby/package.json
@@ -7,7 +7,9 @@
         "node": ">=20.0.0"
     },
     "dependencies": {
-        "apify": "^3.7.0"
+        "apify": "^3.7.0",
+        "tsx": "^4.20.3",
+        "typescript": "^6.0.0"
     },
     "devDependencies": {
         "@apify/eslint-config": "^2.0.0",
@@ -17,8 +19,6 @@
         "eslint-config-prettier": "^10.1.5",
         "globals": "^17.0.0",
         "prettier": "^3.5.3",
-        "tsx": "^4.20.3",
-        "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },

--- a/templates/ts-start/package.json
+++ b/templates/ts-start/package.json
@@ -9,7 +9,9 @@
     "dependencies": {
         "apify": "^3.7.0",
         "axios": "^1.5.0",
-        "cheerio": "^1.0.0-rc.12"
+        "cheerio": "^1.0.0-rc.12",
+        "tsx": "^4.20.3",
+        "typescript": "^6.0.0"
     },
     "devDependencies": {
         "@apify/eslint-config": "^2.0.0",
@@ -19,8 +21,6 @@
         "eslint-config-prettier": "^10.1.5",
         "globals": "^17.0.0",
         "prettier": "^3.5.3",
-        "tsx": "^4.20.3",
-        "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.0"
     },


### PR DESCRIPTION
## Summary

Every ts-* template declares `tsx` and `typescript` in `devDependencies`, but the template's own runtime scripts require both:

```json
"start:dev": "tsx src/main.ts",
"build": "tsc"
```

If `npm install` runs in an environment where devDependencies are skipped (`NODE_ENV=production`, `npm install --omit=dev`, npm 11's tighter production defaults, or any parent installer that forwards those flags), a freshly scaffolded project fails immediately.

This PR moves `tsx` and `typescript` from `devDependencies` to `dependencies` in the 12 ts-* templates whose `start:dev`/`build` scripts invoke them. `ts-start-bun` (runs `bun src/main.ts` directly) and `ts-playwright-test-runner` (already lists both in `dependencies`) are left unchanged.

## Reproducer

```console
$ NODE_ENV=production apify create tmp -t ts-empty
$ cd tmp && apify run
sh: tsx: not found
Error: /usr/local/bin/npm exited with code 127

$ npm run build
sh: tsc: not found
# `npx tsc` then quietly installs the deprecated `tsc@2.0.4` squatter
# ("This is not the tsc command you are looking for")
```

The `.bin/tsx` and `.bin/tsc` shims are absent because npm never installed them:

```console
$ ls node_modules/.bin/tsx
ls: cannot access 'node_modules/.bin/tsx': No such file or directory
$ ls node_modules/typescript
ls: cannot access 'node_modules/typescript': No such file or directory
```

Workarounds users currently need to discover on their own:

```console
$ NODE_ENV=development npm install
# or
$ npm install --include=dev
```

## Why this is safe for image size

The Dockerfile builder stage already passes `--include=dev`, so image builds are unaffected. The runtime image copies the compiled `dist/` from the builder and installs with `--omit=dev --omit=optional` — neither `tsx` nor `typescript` is ever installed into the runtime image today, and this PR does not change that (both remain absent because the runtime image starts from `dist/main.js`, which needs neither). Only the local `apify run`/`npm run build` flows benefit.

## Changes

- `templates/ts-empty/package.json` — move `tsx`, `typescript` to `dependencies`
- `templates/ts-crawlee-cheerio/package.json` — same
- `templates/ts-crawlee-playwright-chrome/package.json` — same
- `templates/ts-crawlee-playwright-camoufox/package.json` — same
- `templates/ts-crawlee-puppeteer-chrome/package.json` — same
- `templates/ts-standby/package.json` — same
- `templates/ts-start/package.json` — same
- `templates/ts-bootstrap-cheerio-crawler/package.json` — same
- `templates/ts-mcp-empty/package.json` — same
- `templates/ts-mcp-proxy/package.json` — same
- `templates/ts-beeai-agent/package.json` — same
- `templates/ts-mastraai/package.json` — same

Unchanged:

- `templates/ts-start-bun/package.json` — `start` uses `bun src/main.ts` directly; `tsx`/`typescript` genuinely are devDeps here.
- `templates/ts-playwright-test-runner/package.json` — already lists both under `dependencies`.

## Test plan

- [ ] `NODE_ENV=production apify create tmp -t ts-empty && cd tmp && apify run` exits 0.
- [ ] `NODE_ENV=production npm run build` succeeds and emits `dist/` for every changed template.
- [ ] Existing Jest template suite still passes (`pnpm run test-node-templates`).
- [ ] Docker image build (unchanged Dockerfile) still succeeds and produces the same runtime image contents.

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._