### PR TITLE
fix(ts-templates): drop <FILL-IN-MODEL> placeholder from generatedBy default

### DIFF
--- a/templates/ts-beeai-agent/.actor/actor.json
+++ b/templates/ts-beeai-agent/.actor/actor.json
@@ -12,7 +12,7 @@
     "output": "./output_schema.json",
     "meta": {
         "templateId": "ts-beeai-agent",
-        "generatedBy": "<FILL-IN-MODEL>"
+        "generatedBy": ""
     },
     "input": "./input_schema.json",
     "dockerfile": "../Dockerfile"

--- a/templates/ts-bootstrap-cheerio-crawler/.actor/actor.json
+++ b/templates/ts-bootstrap-cheerio-crawler/.actor/actor.json
@@ -7,7 +7,7 @@
     "version": "0.0",
     "meta": {
         "templateId": "ts-bootstrap-cheerio-crawler",
-        "generatedBy": "<FILL-IN-MODEL>"
+        "generatedBy": ""
     },
     "dockerfile": "../Dockerfile"
 }

--- a/templates/ts-crawlee-cheerio/.actor/actor.json
+++ b/templates/ts-crawlee-cheerio/.actor/actor.json
@@ -8,7 +8,7 @@
     "buildTag": "latest",
     "meta": {
         "templateId": "ts-crawlee-cheerio",
-        "generatedBy": "<FILL-IN-MODEL>"
+        "generatedBy": ""
     },
     "input": "./input_schema.json",
     "output": "./output_schema.json",

--- a/templates/ts-crawlee-playwright-camoufox/.actor/actor.json
+++ b/templates/ts-crawlee-playwright-camoufox/.actor/actor.json
@@ -7,7 +7,7 @@
     "version": "0.0",
     "meta": {
         "templateId": "ts-crawlee-playwright-camoufox",
-        "generatedBy": "<FILL-IN-MODEL>"
+        "generatedBy": ""
     },
     "input": "./input_schema.json",
     "output": "./output_schema.json",

--- a/templates/ts-crawlee-playwright-chrome/.actor/actor.json
+++ b/templates/ts-crawlee-playwright-chrome/.actor/actor.json
@@ -7,7 +7,7 @@
     "version": "0.0",
     "meta": {
         "templateId": "ts-crawlee-playwright-chrome",
-        "generatedBy": "<FILL-IN-MODEL>"
+        "generatedBy": ""
     },
     "input": "./input_schema.json",
     "output": "./output_schema.json",

--- a/templates/ts-crawlee-puppeteer-chrome/.actor/actor.json
+++ b/templates/ts-crawlee-puppeteer-chrome/.actor/actor.json
@@ -7,7 +7,7 @@
     "version": "0.0",
     "meta": {
         "templateId": "ts-crawlee-puppeteer-chrome",
-        "generatedBy": "<FILL-IN-MODEL>"
+        "generatedBy": ""
     },
     "input": "./input_schema.json",
     "output": "./output_schema.json",

--- a/templates/ts-empty/.actor/actor.json
+++ b/templates/ts-empty/.actor/actor.json
@@ -8,7 +8,7 @@
     "buildTag": "latest",
     "meta": {
         "templateId": "ts-empty",
-        "generatedBy": "<FILL-IN-MODEL>"
+        "generatedBy": ""
     },
     "dockerfile": "../Dockerfile"
 }

--- a/templates/ts-mastraai/.actor/actor.json
+++ b/templates/ts-mastraai/.actor/actor.json
@@ -12,7 +12,7 @@
     "output": "./output_schema.json",
     "meta": {
         "templateId": "ts-mastraai",
-        "generatedBy": "<FILL-IN-MODEL>"
+        "generatedBy": ""
     },
     "input": "./input_schema.json",
     "dockerfile": "../Dockerfile"

--- a/templates/ts-mcp-empty/.actor/actor.json
+++ b/templates/ts-mcp-empty/.actor/actor.json
@@ -9,7 +9,7 @@
     "usesStandbyMode": true,
     "meta": {
         "templateId": "ts-mcp-empty",
-        "generatedBy": "<FILL-IN-MODEL>"
+        "generatedBy": ""
     },
     "input": {
         "title": "Actor input schema",

--- a/templates/ts-mcp-proxy/.actor/actor.json
+++ b/templates/ts-mcp-proxy/.actor/actor.json
@@ -9,7 +9,7 @@
     "usesStandbyMode": true,
     "meta": {
         "templateId": "ts-mcp-proxy",
-        "generatedBy": "<FILL-IN-MODEL>"
+        "generatedBy": ""
     },
     "input": {
         "title": "Actor input schema",

--- a/templates/ts-playwright-test-runner/.actor/actor.json
+++ b/templates/ts-playwright-test-runner/.actor/actor.json
@@ -8,7 +8,7 @@
     "buildTag": "latest",
     "meta": {
         "templateId": "ts-playwright-test-runner",
-        "generatedBy": "<FILL-IN-MODEL>"
+        "generatedBy": ""
     },
     "storages": {
         "dataset": "./dataset_schema.json",

--- a/templates/ts-standby/.actor/actor.json
+++ b/templates/ts-standby/.actor/actor.json
@@ -9,7 +9,7 @@
     "usesStandbyMode": true,
     "meta": {
         "templateId": "ts-standby",
-        "generatedBy": "<FILL-IN-MODEL>"
+        "generatedBy": ""
     },
     "dockerfile": "../Dockerfile"
 }

--- a/templates/ts-start-bun/.actor/actor.json
+++ b/templates/ts-start-bun/.actor/actor.json
@@ -7,7 +7,7 @@
     "version": "0.0",
     "meta": {
         "templateId": "ts-start-bun",
-        "generatedBy": "<FILL-IN-MODEL>"
+        "generatedBy": ""
     },
     "input": "./input_schema.json",
     "output": "./output_schema.json",

--- a/templates/ts-start/.actor/actor.json
+++ b/templates/ts-start/.actor/actor.json
@@ -7,7 +7,7 @@
     "version": "0.0",
     "meta": {
         "templateId": "ts-start",
-        "generatedBy": "<FILL-IN-MODEL>"
+        "generatedBy": ""
     },
     "input": "./input_schema.json",
     "output": "./output_schema.json",


### PR DESCRIPTION
## Summary

Every TypeScript template's `.actor/actor.json` currently ships with:

```json
"meta": {
    "templateId": "ts-empty",
    "generatedBy": "<FILL-IN-MODEL>"
}
```

`<FILL-IN-MODEL>` is a literal placeholder token that the AGENTS.md instructions ask agents (or users) to overwrite with the tool + model name that generated the code — e.g. `"Claude Code with Claude Sonnet 4.5"`. From `agent-bases/ts.AGENTS.md`:

> Important: Before you begin, fill in the `generatedBy` property in the meta section of `.actor/actor.json`. Replace it with the tool and model you're currently using [...]. This helps Apify monitor and improve AGENTS.md for specific AI tools and models.

In practice the overwrite step is easy to skip — agents that follow the rest of the AGENTS.md flow but miss this preamble, and human users who don't read AGENTS.md at all, both end up pushing production Actors whose `actor.json` publishes the literal string `<FILL-IN-MODEL>` in its metadata.

## Fix

Default the value to an empty string instead:

```diff
     "meta": {
         "templateId": "ts-empty",
-        "generatedBy": "<FILL-IN-MODEL>"
+        "generatedBy": ""
     },
```

- Unfilled deploys ship `"generatedBy": ""` (no visible garbage in production metadata) rather than the literal placeholder token.
- The key is still present, so the AGENTS.md instruction ("fill in the `generatedBy` property in the meta section of `.actor/actor.json`") still reads the same and telemetry consumers still find the field.
- No changes to any per-template AGENTS.md or the shared `agent-bases/ts.AGENTS.md` are required.

## Scope

Applied to all 14 TypeScript templates:

- `ts-beeai-agent`
- `ts-bootstrap-cheerio-crawler`
- `ts-crawlee-cheerio`
- `ts-crawlee-playwright-camoufox`
- `ts-crawlee-playwright-chrome`
- `ts-crawlee-puppeteer-chrome`
- `ts-empty`
- `ts-mastraai`
- `ts-mcp-empty`
- `ts-mcp-proxy`
- `ts-playwright-test-runner`
- `ts-standby`
- `ts-start`
- `ts-start-bun`

Total diff: `14 files changed, 14 insertions(+), 14 deletions(-)` — one-liner per file.

JS and Python templates carry the same `<FILL-IN-MODEL>` default; leaving them for a follow-up PR so this one stays scoped and easy to review.

## Reproducer

```bash
$ apify create my-actor -t ts-empty
$ cat my-actor/.actor/actor.json | grep generatedBy
        "generatedBy": "<FILL-IN-MODEL>"
$ cd my-actor && apify push   # user did not read AGENTS.md preamble
# → deployed Actor's actor.json now carries "generatedBy": "<FILL-IN-MODEL>"
#   as public metadata.
```

## Follow-ups (out of scope for this PR)

- Same fix in `js-*` (13 templates) and `python-*` (17 templates) — mechanical extension.
- Consider having `apify push` warn (not block) when a required-to-fill placeholder pattern (`/^<.*>$/`) is detected in metadata fields; would catch the class of issue for future scaffolds that add similar placeholders.

## Test plan

- [x] `grep -c "FILL-IN-MODEL" templates/ts-*/.actor/actor.json` returns 0 across all TS templates on this branch.
- [x] `grep -c '"generatedBy": ""' templates/ts-*/.actor/actor.json` returns 14.
- [ ] Zip regeneration in `dist/templates/ts-*.zip` picks up the change on the next `chore: Update template archives` CI run.
- [ ] Manifest-driven consumers (`@apify/actor-templates` npm package, `apify create -t ts-empty`, Console template gallery) get the change once master is refreshed.

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._