### PR TITLE
fix(ts-empty): stop deprecated lodash.isequal warning on npm install

### DIFF
--- a/templates/ts-empty/package.json
+++ b/templates/ts-empty/package.json
@@ -10,6 +10,9 @@
         "apify": "^3.7.0",
         "@crawlee/cheerio": "^3.15.3"
     },
+    "overrides": {
+        "ow": "^2.0.0"
+    },
     "devDependencies": {
         "@apify/eslint-config": "^2.0.0",
         "@apify/tsconfig": "^0.1.1",


### PR DESCRIPTION
## Summary

Every `npm install` in a freshly-scaffolded `ts-empty` Actor prints a `lodash.isequal` deprecation warning. This PR silences it by pinning the transitive `ow` dependency to `^2.0.0` (which dropped `lodash.isequal` in favor of `fast-equals`) via npm `overrides`.

## Reproducer

```
$ apify create my-actor -t ts-empty
$ cd my-actor
$ npm install
...
npm warn deprecated lodash.isequal@4.5.0: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
```

## Trace

`lodash.isequal` arrives transitively via `ow`, from two paths:

```
$ npm ls lodash.isequal --all
ts-empty@0.0.1
+-- @crawlee/cheerio@3.17.0
| `-- @crawlee/http@3.17.0
|   `-- got-scraping@4.2.1
|     `-- ow@1.1.1
|       `-- lodash.isequal@4.5.0 deduped
`-- apify@3.7.2
  `-- ow@0.28.2
    `-- lodash.isequal@4.5.0
```

`ow` dropped `lodash.isequal` starting in v2 (uses `fast-equals` instead). Both `ow@2.x` and `ow@3.x` declare `node: >=18` engines, matching this template's `engines.node`.

## Fix

Add an npm `overrides` block pinning `ow` to `^2.0.0`:

```diff
     "dependencies": {
         "apify": "^3.7.0",
         "@crawlee/cheerio": "^3.15.3"
     },
+    "overrides": {
+        "ow": "^2.0.0"
+    },
```

## Verification

```
$ rm -rf node_modules package-lock.json
$ npm install
# no lodash.isequal deprecation warning

$ npm ls lodash.isequal --all
ts-empty@0.0.1 /private/tmp/f75-repro
`-- (empty)

$ npm ls ow --all
ts-empty@0.0.1
+-- @crawlee/cheerio@3.17.0
| `-- @crawlee/http@3.17.0
|   `-- ... `-- ow@2.0.0
`-- apify@3.7.2 `-- ow@2.0.0

$ npm run build && node dist/main.js
INFO  System info {"apifyVersion":"3.7.2","crawleeVersion":"3.17.0", ...}
INFO  Hello from the Actor!
```

Install + build + run all succeed cleanly.

## Scope

This PR patches only `ts-empty` as the canonical minimal scaffold. The same warning shows up in every other `ts-*` template that pulls in `apify` and/or `@crawlee/*` (i.e. essentially all of them). Happy to fan the same three-line override across the other templates in a follow-up if maintainers agree with the shape.

The permanent upstream fix is in `apify-sdk-js` (bump `ow` in `apify`) and in `crawlee` (bump `ow` in `got-scraping`); those are out of scope for this repo.

## Test plan

- [x] Fresh `npm install` on `ts-empty` scaffold produces no `lodash.isequal` warning.
- [x] `npm ls lodash.isequal --all` returns `(empty)`.
- [x] `npm run build` + `node dist/main.js` still succeed against the Apify + Crawlee runtime.

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._