### PR TITLE
chore(deps): bump python-scrapy wrapper to Apify SDK v4

### DIFF
--- a/templates/python-crewai/requirements.txt
+++ b/templates/python-crewai/requirements.txt
@@ -1,9 +1,6 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-# Pinned to apify v3: crewai-tools' ApifyActorsTool needs langchain-apify, which requires
-# apify-client < 3.0.0, while apify v4 requires apify-client >= 3.0.0. Bump once langchain-apify
-# supports apify-client v3.
 apify >= 3.0.0, < 4.0.0
 apify-client
 langchain-apify >= 0.1.0, < 1.0.0

--- a/wrappers/python-scrapy/requirements_apify.txt
+++ b/wrappers/python-scrapy/requirements_apify.txt
@@ -1,5 +1,5 @@
 # Add your dependencies here.
 # See https://pip.pypa.io/en/latest/reference/requirements-file-format/
 # for how to format them
-apify[scrapy] >= 3.3.0, < 4.0.0
+apify[scrapy] >= 4.0.0, < 5.0.0
 scrapy >= 2.14.0, < 3.0.0


### PR DESCRIPTION
Follow-up to #861, which bumped the Python templates to Apify SDK v4 but missed two leftovers:

- **`wrappers/python-scrapy`**: the Scrapy wrapper (used by `apify` CLI to wrap an existing Scrapy project, shipped as `dist/wrappers/python-scrapy.zip`) still pinned `apify[scrapy] >= 3.3.0, < 4.0.0`. Bumped to `>= 4.0.0, < 5.0.0`. The wrapper code (`apply_apify_settings`, etc.) is already v4-compatible, so no code changes.
- **`python-crewai`**: dropped the inline "pinned to apify v3" comment — the reason it stays on v3 (langchain-apify needs apify-client < 3) is tracked in #863. The pin itself is unchanged.

Lint (`ruff`) and type-check (`ty`) pass.

*✍️ Drafted by Claude Code*
