### PR TITLE
fix(renovate): skip browser downloads during artifact update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,10 @@
     "constraints": {
         "pnpm": "^11.0.0"
     },
+    "env": {
+        "PUPPETEER_SKIP_DOWNLOAD": "true",
+        "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD": "1"
+    },
     "packageRules": [
         {
             "matchUpdateTypes": ["patch", "minor"],


### PR DESCRIPTION
## Summary
- Every Renovate PR that bumps a package.json dependency (puppeteer, eslint, typescript, patch/minor group, camoufox-js, lock file maintenance, etc.) is failing CI with `ERR_PNPM_OUTDATED_LOCKFILE`, because the `renovate/artifacts` step never manages to write back an updated `pnpm-lock.yaml`.
- Confirmed locally: checking out the affected branches and running `pnpm install --no-frozen-lockfile` resolves cleanly and produces a valid lockfile — the dependency graph is fine, so the problem is in Renovate's own environment, not the repo.
- Root cause: `puppeteer`/`playwright` postinstall scripts download a full browser binary, which appears to fail (network-restricted sandbox) inside Renovate's own artifact-update run.
- Fix: set `PUPPETEER_SKIP_DOWNLOAD` / `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` via Renovate's `env` config. This only affects the install command Renovate itself runs to compute the lockfile — real CI workflows are untouched and still download real browsers for tests. Verified the resulting lockfile is identical with or without the download.

## Test plan
- [ ] After merge, confirm a queued Node dependency PR (e.g. #790, #797, #846, #855, #882) gets a green `renovate/artifacts` check on its next rebase
- [ ] Confirm CI (`Lint and test`) then passes `pnpm install --frozen-lockfile` on that PR
- [ ] Confirm real template CI (Docker builds, LLM AI template tests) still downloads and uses actual browsers successfully