### PR TITLE
chore: pin apify to 4.0.2b5 beta in Python templates

### DIFF
--- a/templates/python-beautifulsoup/requirements.txt
+++ b/templates/python-beautifulsoup/requirements.txt
@@ -1,7 +1,7 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify >= 4.0.0, < 5.0.0
+apify == 4.0.2b5
 beautifulsoup4[lxml] >= 4.0.0, < 5.0.0
 httpx >= 0.28.0, < 1.0.0
 types-beautifulsoup4 >= 4.0.0, < 5.0.0

--- a/templates/python-crawlee-beautifulsoup/requirements.txt
+++ b/templates/python-crawlee-beautifulsoup/requirements.txt
@@ -1,5 +1,5 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify >= 4.0.0, < 5.0.0
+apify == 4.0.2b5
 crawlee[beautifulsoup] >= 1.7.0

--- a/templates/python-crawlee-parsel/requirements.txt
+++ b/templates/python-crawlee-parsel/requirements.txt
@@ -1,5 +1,5 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify >= 4.0.0, < 5.0.0
+apify == 4.0.2b5
 crawlee[parsel] >= 1.7.0

--- a/templates/python-crawlee-playwright-camoufox/requirements.txt
+++ b/templates/python-crawlee-playwright-camoufox/requirements.txt
@@ -1,6 +1,6 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify >= 4.0.0, < 5.0.0
+apify == 4.0.2b5
 crawlee[playwright] >= 1.7.0
 camoufox[geoip] >= 0.4.5, < 1.0.0

--- a/templates/python-crawlee-playwright/requirements.txt
+++ b/templates/python-crawlee-playwright/requirements.txt
@@ -1,5 +1,5 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify >= 4.0.0, < 5.0.0
+apify == 4.0.2b5
 crawlee[playwright] >= 1.7.0

--- a/templates/python-empty/requirements.txt
+++ b/templates/python-empty/requirements.txt
@@ -1,4 +1,4 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify >= 4.0.0, < 5.0.0
+apify == 4.0.2b5

--- a/templates/python-langgraph/requirements.txt
+++ b/templates/python-langgraph/requirements.txt
@@ -1,7 +1,7 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify >= 4.0.0, < 5.0.0
+apify == 4.0.2b5
 langchain >= 1.0.0, < 2.0.0
 langchain-openai >= 1.0.0, < 2.0.0
 langgraph >= 1.0.0, < 2.0.0

--- a/templates/python-llamaindex-agent/requirements.txt
+++ b/templates/python-llamaindex-agent/requirements.txt
@@ -1,7 +1,7 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify >= 4.0.0, < 5.0.0
+apify == 4.0.2b5
 apify-client
 llama-index >= 0.14.0, < 1.0.0
 polars >= 1.0.0, < 2.0.0

--- a/templates/python-mcp-empty/requirements.txt
+++ b/templates/python-mcp-empty/requirements.txt
@@ -1,7 +1,7 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify >= 4.0.0, < 5.0.0
+apify == 4.0.2b5
 apify-client
 fastmcp >= 3.0.0, < 4.0.0
 mcp >= 1.25.0, < 2.0.0

--- a/templates/python-mcp-proxy/requirements.txt
+++ b/templates/python-mcp-proxy/requirements.txt
@@ -1,7 +1,7 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify >= 4.0.0, < 5.0.0
+apify == 4.0.2b5
 apify-client
 arxiv-mcp-server >= 0.3.1, < 1.0.0
 fastapi >= 0.135.0, < 1.0.0

--- a/templates/python-playwright/requirements.txt
+++ b/templates/python-playwright/requirements.txt
@@ -1,5 +1,5 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify >= 4.0.0, < 5.0.0
+apify == 4.0.2b5
 playwright >= 1.58.0, < 2.0.0

--- a/templates/python-pydanticai/requirements.txt
+++ b/templates/python-pydanticai/requirements.txt
@@ -1,5 +1,5 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify >= 4.0.0, < 5.0.0
+apify == 4.0.2b5
 pydantic-ai >= 2.0.0, < 3.0.0

--- a/templates/python-scrapy/requirements.txt
+++ b/templates/python-scrapy/requirements.txt
@@ -1,5 +1,5 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify[scrapy] >= 4.0.0, < 5.0.0
+apify[scrapy] == 4.0.2b5
 scrapy >= 2.14.0, < 3.0.0

--- a/templates/python-selenium/requirements.txt
+++ b/templates/python-selenium/requirements.txt
@@ -1,5 +1,5 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify >= 4.0.0, < 5.0.0
+apify == 4.0.2b5
 selenium >= 4.41.0, < 5.0.0

--- a/templates/python-smolagents/requirements.txt
+++ b/templates/python-smolagents/requirements.txt
@@ -1,5 +1,5 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify >= 4.0.0, < 5.0.0
+apify == 4.0.2b5
 smolagents[openai] >= 1.0.0, < 2.0.0

--- a/templates/python-standby/requirements.txt
+++ b/templates/python-standby/requirements.txt
@@ -1,4 +1,4 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify >= 4.0.0, < 5.0.0
+apify == 4.0.2b5

--- a/templates/python-start/requirements.txt
+++ b/templates/python-start/requirements.txt
@@ -1,7 +1,7 @@
 # Feel free to add your Python dependencies below. For formatting guidelines, see:
 # https://pip.pypa.io/en/latest/reference/requirements-file-format/
 
-apify >= 4.0.0, < 5.0.0
+apify == 4.0.2b5
 beautifulsoup4[lxml] >= 4.0.0, < 5.0.0
 httpx >= 0.28.0, < 1.0.0
 types-beautifulsoup4 >= 4.0.0, < 5.0.0

--- a/templates/python-uv/pyproject.toml
+++ b/templates/python-uv/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "An Apify Actor with dependencies managed by uv."
 requires-python = ">=3.14"
 dependencies = [
-    "apify>=4.0.0,<5.0.0",
+    "apify==4.0.2b5",
 ]
 
 [dependency-groups]

--- a/templates/python-uv/uv.lock
+++ b/templates/python-uv/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "apify"
-version = "4.0.1"
+version = "4.0.2b5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apify-client", extra = ["brotli"] },
@@ -28,9 +28,9 @@ dependencies = [
     { name = "websockets" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/5b/61070741e4607a5477f7fda6da58904f9e63a1afa2be478d6f85752a7017/apify-4.0.1.tar.gz", hash = "sha256:8ac4b0551b4e1957a75fed3bc5ea2735c05631f7a3ef5c01be77068b1c8dd142", size = 116642, upload-time = "2026-08-07T07:12:44.598Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/4b/968fdd5a5bdb4c6927edd8b5060b68d7bbeab7e231d9db5dcc8c52e7153b/apify-4.0.2b5.tar.gz", hash = "sha256:739e6c46fc5ddecd644cbae70ccc16e36f25d1bf1d9d207a7e4861838de7d2b2", size = 127568, upload-time = "2026-08-31T07:10:44.463Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/5b/7f9f8f4507b8d0db5404ae79fc767effef6dfa78db772ac70ee3b732b8bf/apify-4.0.1-py3-none-any.whl", hash = "sha256:04581ef95500bcd839d0704671a39f7b746fe9a81d06fd6b3233001441ce2f9e", size = 122242, upload-time = "2026-08-07T07:12:43.117Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/4d/ea392e9a773de275f7a08274d9778e5beb7f5f9f21b180b5a8f9effe6aee/apify-4.0.2b5-py3-none-any.whl", hash = "sha256:ae2f05cc25dcebece91fc9a0ddaedb765dbfce5cf45117e84573feab6241035c", size = 132184, upload-time = "2026-08-31T07:10:43.038Z" },
 ]
 
 [[package]]
@@ -430,7 +430,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "apify", specifier = ">=4.0.0,<5.0.0" }]
+requires-dist = [{ name = "apify", specifier = "==4.0.2b5" }]
 
 [package.metadata.requires-dev]
 dev = [

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -63,9 +63,9 @@ const APIFY_SDK_JS_LATEST_VERSION = spawnSync(NPM_COMMAND, ['view', 'apify', 've
     .stdout.toString()
     .trim();
 
-const APIFY_SDK_PYTHON_LATEST_VERSION = spawnSync(PYTHON_COMMAND, ['-m', 'pip', 'index', 'versions', 'apify'])
-    .stdout.toString()
-    .match(/\((.*)\)/)[1];
+// Temporary override for beta testing (this PR is not meant to be merged): the templates pin
+// the 4.0.2b5 pre-release, which `pip index versions` never reports as the latest version.
+const APIFY_SDK_PYTHON_LATEST_VERSION = '4.0.2b5';
 
 const checkSpawnResult = ({ status, stdout, stderr }) => {
     if (stdout?.toString()) {


### PR DESCRIPTION
Pins `apify` to the `4.0.2b5` beta (exact pin — pip does not select pre-releases from a version range) in all Python templates, to run the template smoke tests against the upcoming SDK release. Covers 17 `requirements.txt` templates plus `python-uv` (`pyproject.toml` + `uv.lock`).

`python-crewai` is left unchanged: it is still on SDK v3 because `langchain-apify` caps `apify-client < 3.0.0`, which is incompatible with apify 4.x (requires `apify-client >= 3.1.0`).

Not meant to be merged as-is — testing only.

*✍️ Drafted by Claude Code*