### PR TITLE
fix(templates): bump vitest to ^5.0.0

### DIFF
--- a/templates/js-bootstrap-cheerio-crawler/package.json
+++ b/templates/js-bootstrap-cheerio-crawler/package.json
@@ -15,7 +15,7 @@
         "eslint": "^9.29.0",
         "eslint-config-prettier": "^10.1.5",
         "prettier": "^3.5.3",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "node src/main.js",

--- a/templates/js-crawlee-cheerio/package.json
+++ b/templates/js-crawlee-cheerio/package.json
@@ -15,7 +15,7 @@
         "eslint": "^9.29.0",
         "eslint-config-prettier": "^10.1.5",
         "prettier": "^3.5.3",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "node src/main.js",

--- a/templates/js-crawlee-playwright-camoufox/package.json
+++ b/templates/js-crawlee-playwright-camoufox/package.json
@@ -17,7 +17,7 @@
         "eslint": "^9.29.0",
         "eslint-config-prettier": "^10.1.5",
         "prettier": "^3.5.3",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "node src/main.js",

--- a/templates/js-crawlee-playwright-chrome/package.json
+++ b/templates/js-crawlee-playwright-chrome/package.json
@@ -13,7 +13,7 @@
         "eslint": "^9.29.0",
         "eslint-config-prettier": "^10.1.5",
         "prettier": "^3.5.3",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "node src/main.js",

--- a/templates/js-crawlee-puppeteer-chrome/package.json
+++ b/templates/js-crawlee-puppeteer-chrome/package.json
@@ -13,7 +13,7 @@
         "eslint": "^9.29.0",
         "eslint-config-prettier": "^10.1.5",
         "prettier": "^3.5.3",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "node src/main.js",

--- a/templates/js-empty/package.json
+++ b/templates/js-empty/package.json
@@ -15,7 +15,7 @@
         "eslint": "^9.29.0",
         "eslint-config-prettier": "^10.1.5",
         "prettier": "^3.5.3",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "node ./src/main.js",

--- a/templates/js-langchain/package.json
+++ b/templates/js-langchain/package.json
@@ -31,6 +31,6 @@
         "eslint": "^9.29.0",
         "eslint-config-prettier": "^10.1.5",
         "prettier": "^3.5.3",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     }
 }

--- a/templates/js-langgraph-agent/package.json
+++ b/templates/js-langgraph-agent/package.json
@@ -30,6 +30,6 @@
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.5",
         "prettier": "^3.8.1",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     }
 }

--- a/templates/js-standby/package.json
+++ b/templates/js-standby/package.json
@@ -14,7 +14,7 @@
         "eslint": "^9.29.0",
         "eslint-config-prettier": "^10.1.5",
         "prettier": "^3.5.3",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "node ./src/main.js",

--- a/templates/js-start/package.json
+++ b/templates/js-start/package.json
@@ -18,6 +18,6 @@
     "author": "It's not you it's me",
     "license": "ISC",
     "devDependencies": {
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     }
 }

--- a/templates/ts-beeai-agent/package.json
+++ b/templates/ts-beeai-agent/package.json
@@ -23,7 +23,7 @@
         "tsx": "^4.22.3",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.60.0",
-        "vitest": "^4.1.7"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "npm run start:dev",

--- a/templates/ts-bootstrap-cheerio-crawler/package.json
+++ b/templates/ts-bootstrap-cheerio-crawler/package.json
@@ -21,7 +21,7 @@
         "tsx": "^4.20.3",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "npm run start:dev",

--- a/templates/ts-crawlee-cheerio/package.json
+++ b/templates/ts-crawlee-cheerio/package.json
@@ -21,7 +21,7 @@
         "tsx": "^4.20.3",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "npm run start:dev",

--- a/templates/ts-crawlee-playwright-camoufox/package.json
+++ b/templates/ts-crawlee-playwright-camoufox/package.json
@@ -23,7 +23,7 @@
         "tsx": "^4.20.3",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "npm run start:dev",

--- a/templates/ts-crawlee-playwright-chrome/package.json
+++ b/templates/ts-crawlee-playwright-chrome/package.json
@@ -22,7 +22,7 @@
         "tsx": "^4.20.3",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "npm run start:dev",

--- a/templates/ts-crawlee-puppeteer-chrome/package.json
+++ b/templates/ts-crawlee-puppeteer-chrome/package.json
@@ -22,7 +22,7 @@
         "tsx": "^4.20.3",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "npm run start:dev",

--- a/templates/ts-empty/package.json
+++ b/templates/ts-empty/package.json
@@ -21,7 +21,7 @@
         "tsx": "^4.20.3",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "npm run start:dev",

--- a/templates/ts-mastraai/package.json
+++ b/templates/ts-mastraai/package.json
@@ -24,7 +24,7 @@
         "tsx": "^4.21.0",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "npm run start:dev",

--- a/templates/ts-mcp-empty/package.json
+++ b/templates/ts-mcp-empty/package.json
@@ -26,7 +26,7 @@
         "tsx": "^4.20.3",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "npm run start:dev",

--- a/templates/ts-mcp-proxy/package.json
+++ b/templates/ts-mcp-proxy/package.json
@@ -28,7 +28,7 @@
         "tsx": "^4.20.3",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "npm run start:dev",

--- a/templates/ts-standby/package.json
+++ b/templates/ts-standby/package.json
@@ -20,7 +20,7 @@
         "tsx": "^4.20.3",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "npm run start:dev",

--- a/templates/ts-start-bun/package.json
+++ b/templates/ts-start-bun/package.json
@@ -22,7 +22,7 @@
         "tsx": "^4.20.3",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "bun src/main.ts",

--- a/templates/ts-start/package.json
+++ b/templates/ts-start/package.json
@@ -22,7 +22,7 @@
         "tsx": "^4.20.3",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
-        "vitest": "^4.1.0"
+        "vitest": "^5.0.0"
     },
     "scripts": {
         "start": "npm run start:dev",


### PR DESCRIPTION
> [!NOTE] 
> **TL;DR**
> `npm install` in every Node template has been broken on Node 22 since `vitest@5.0.0` was published today at 12:24:30Z. Bumping the templates from `^4.1.0` to `^5.0.0` fixes it. **Do not merge before 2026-09-04 12:24:30Z** — until then `min-release-age=1` refuses 5.0.0 on npm 11, so the Node 24 and Docker legs fail by design.

## What broke

Every Node 22 leg of `Test Templates` fails. Node 24 legs pass.

```
stderr npm error Cannot read properties of null (reading 'edgesOut')
```

The stack is `#loadPeerSet` in `@npmcli/arborist/lib/arborist/build-ideal-tree.js:1289` — an npm 10 bug. Node 22 bundles npm 10.9.8; Node 24 bundles npm 11.17.0.

vitest 4 declares an unbounded `peerOptional` on `@vitest/browser-playwright`, so arborist resolves that peer at dist-tag `latest` = 5.0.0, then fails to reconcile the peer set and throws. The templates' `^4.1.0` range never accepted 5.0.0 — the release only had to exist.

Nothing was installed from 5.0.0: the crash is in `buildIdealTree`, before any tarball fetch.

## Timeline

| When (UTC) | What |
|---|---|
| 2026-09-03 00:25 | Last fully green master run (33699476711) |
| 2026-09-03 12:22:01 | `@vitest/browser-playwright@5.0.0` published |
| 2026-09-03 12:24:30 | `vitest@5.0.0` published |
| 2026-09-03 12:20 | Master run 33754690534 — ubuntu legs pass (installed before the publish), slower windows legs fail |
| 2026-09-03 12:34 onward | Every run fully red |

The intra-run split in 33754690534 is the clock: legs that reached `npm install` before 12:24:30 passed.

## Why this cannot merge today

Each template ships an `.npmrc` with `min-release-age=1` (added in #750), and the test copies it into the tmp dir along with the rest of the template. That setting landed in npm 11 — npm 10 does not know the key (`npm config get min-release-age` → `undefined` on 10.9.8, `null` on 11.16.0).

So the two npm versions fail on opposite sides:

| | npm 10.9.8 (Node 22) | npm 11.x (Node 24, Docker base images) |
|---|---|---|
| `vitest ^4.1.0` | `edgesOut` crash | installs fine |
| `vitest ^5.0.0` | installs fine | `ETARGET` — 5.0.0 is under 24h old |

That is what run 33802694997 shows on this branch: Node 22 legs green, all Node 24 legs and one Docker leg red with

```
npm error notarget No matching version found for vitest@^5.0.0 with a date before 9/2/2026, 8:31:51 PM.
```

The guard is working as intended. `vitest@5.0.0` and its sub-packages were published between 12:21:48Z and 12:24:30Z, so the floor clears at **2026-09-04 12:24:30Z**. Re-run the checks after that and every leg should pass — npm 11 will accept 5.0.0, npm 10 already does.

Please do not weaken or bypass `min-release-age` to land this sooner.

## Verification

All four combinations reproduced locally with the template `.npmrc` in place, using an `npm@10.9.8` shim for the npm 10 rows — the exact version that crashes in CI. Results match the table above.

End to end on this branch, under npm 10.9.8:

- `js-crawlee-cheerio` — `added 414 packages in 24s`, resolved vitest 5.0.0; `npm test` 1 passed; `lint` and `format:check` clean
- `ts-start` — `added 438 packages in 5s`; `npm test` 1 passed; `lint` clean

23 templates changed, one line each.

## Worth knowing before merge

**`engines` mismatch.** vitest 5 requires `^22.12.0 || ^24.0.0 || >=26.0.0`. Several templates declare `>=18.0.0` or `>=20.0.0`. Users on Node 18 or 20 will get an `EBADENGINE` warning and a vitest that will not run. CI does not catch this: the matrix is Node 22 and 24 only, and `checkNodeTemplate` runs `lint`, `format:check` and `apify run` — it never runs the template's own `npm test`. Bumping `engines.node` is a separate, user-facing decision, so it is not in this PR.
