### PR TITLE
chore: Update Camoufox version in Python template 

### DIFF
--- a/templates/python-crawlee-playwright-camoufox/requirements.txt
+++ b/templates/python-crawlee-playwright-camoufox/requirements.txt
@@ -3,4 +3,4 @@
 
 apify >= 4.0.0, < 5.0.0
 crawlee[playwright] >= 1.7.0
-camoufox[geoip] >= 0.4.5, < 1.0.0
+camoufox[geoip] >= 0.5.6, < 1.0.0


### PR DESCRIPTION
Bump lower bound to make the Camoufox template compatible with the latest Playwright 1.61.0 and 1.62.0