### PR TITLE
fix(templates): bound the crawl in the hand-rolled Python scrapers

### DIFF
--- a/templates/python-beautifulsoup/my_actor/main.py
+++ b/templates/python-beautifulsoup/my_actor/main.py
@@ -14,7 +14,7 @@ from apify import Actor, Request
 from bs4 import BeautifulSoup
 from httpx import AsyncClient
 
-# Limit the crawl to max requests. Remove or increase it for crawling all links.
+# Limit the crawl to max requests. Increase it to crawl more links.
 MAX_REQUESTS_PER_CRAWL = 10
 
 
@@ -102,5 +102,5 @@ async def main() -> None:
 
                 finally:
                     # Mark the request as handled to ensure it is not processed again.
-                    await request_queue.mark_request_as_handled(new_request)
+                    await request_queue.mark_request_as_handled(request)
                     handled_requests += 1

--- a/templates/python-beautifulsoup/my_actor/main.py
+++ b/templates/python-beautifulsoup/my_actor/main.py
@@ -14,6 +14,9 @@ from apify import Actor, Request
 from bs4 import BeautifulSoup
 from httpx import AsyncClient
 
+# Limit the crawl to max requests. Remove or increase it for crawling all links.
+MAX_REQUESTS_PER_CRAWL = 10
+
 
 async def main() -> None:
     """Define a main entry point for the Apify Actor.
@@ -46,8 +49,10 @@ async def main() -> None:
 
         # Create an HTTPX client to fetch the HTML content of the URLs.
         async with AsyncClient() as client:
+            handled_requests = 0
+
             # Process the URLs from the request queue.
-            while request := await request_queue.fetch_next_request():
+            while handled_requests < MAX_REQUESTS_PER_CRAWL and (request := await request_queue.fetch_next_request()):
                 url = request.url
 
                 if not isinstance(request.user_data['depth'], (str, int)):
@@ -98,3 +103,4 @@ async def main() -> None:
                 finally:
                     # Mark the request as handled to ensure it is not processed again.
                     await request_queue.mark_request_as_handled(new_request)
+                    handled_requests += 1

--- a/templates/python-playwright/my_actor/main.py
+++ b/templates/python-playwright/my_actor/main.py
@@ -18,7 +18,7 @@ from playwright.async_api import async_playwright
 # When running on the Apify platform, these dependencies are already included
 # in the Actor's Docker image.
 
-# Limit the crawl to max requests. Remove or increase it for crawling all links.
+# Limit the crawl to max requests. Increase it to crawl more links.
 MAX_REQUESTS_PER_CRAWL = 10
 
 

--- a/templates/python-playwright/my_actor/main.py
+++ b/templates/python-playwright/my_actor/main.py
@@ -18,6 +18,9 @@ from playwright.async_api import async_playwright
 # When running on the Apify platform, these dependencies are already included
 # in the Actor's Docker image.
 
+# Limit the crawl to max requests. Remove or increase it for crawling all links.
+MAX_REQUESTS_PER_CRAWL = 10
+
 
 async def main() -> None:
     """Define a main entry point for the Apify Actor.
@@ -59,8 +62,10 @@ async def main() -> None:
             )
             context = await browser.new_context()
 
+            handled_requests = 0
+
             # Process the URLs from the request queue.
-            while request := await request_queue.fetch_next_request():
+            while handled_requests < MAX_REQUESTS_PER_CRAWL and (request := await request_queue.fetch_next_request()):
                 url = request.url
 
                 if not isinstance(request.user_data['depth'], (str, int)):
@@ -105,3 +110,4 @@ async def main() -> None:
                     await page.close()
                     # Mark the request as handled to ensure it is not processed again.
                     await request_queue.mark_request_as_handled(request)
+                    handled_requests += 1

--- a/templates/python-selenium/my_actor/main.py
+++ b/templates/python-selenium/my_actor/main.py
@@ -25,6 +25,9 @@ from selenium.webdriver.common.by import By
 # Limit the crawl to max requests. Increase it to crawl more links.
 MAX_REQUESTS_PER_CRAWL = 10
 
+# Matches Playwright's default navigation timeout, which the sibling templates rely on.
+PAGE_LOAD_TIMEOUT_SECS = 30
+
 
 async def main() -> None:
     """Define a main entry point for the Apify Actor.
@@ -65,6 +68,9 @@ async def main() -> None:
         chrome_options.add_argument('--no-sandbox')
         chrome_options.add_argument('--disable-dev-shm-usage')
         driver = webdriver.Chrome(options=chrome_options)
+
+        # Without this a page that never finishes loading blocks for 120s, the client timeout.
+        driver.set_page_load_timeout(PAGE_LOAD_TIMEOUT_SECS)
 
         # Test WebDriver setup by navigating to an example page.
         driver.get('http://www.example.com')

--- a/templates/python-selenium/my_actor/main.py
+++ b/templates/python-selenium/my_actor/main.py
@@ -22,7 +22,7 @@ from selenium.webdriver.common.by import By
 # When running on the Apify platform, the Chromedriver is already included
 # in the Actor's Docker image.
 
-# Limit the crawl to max requests. Remove or increase it for crawling all links.
+# Limit the crawl to max requests. Increase it to crawl more links.
 MAX_REQUESTS_PER_CRAWL = 10
 
 

--- a/templates/python-selenium/my_actor/main.py
+++ b/templates/python-selenium/my_actor/main.py
@@ -22,6 +22,9 @@ from selenium.webdriver.common.by import By
 # When running on the Apify platform, the Chromedriver is already included
 # in the Actor's Docker image.
 
+# Limit the crawl to max requests. Remove or increase it for crawling all links.
+MAX_REQUESTS_PER_CRAWL = 10
+
 
 async def main() -> None:
     """Define a main entry point for the Apify Actor.
@@ -68,8 +71,10 @@ async def main() -> None:
         if driver.title != 'Example Domain':
             raise ValueError('Failed to open example page.')
 
+        handled_requests = 0
+
         # Process the URLs from the request queue.
-        while request := await request_queue.fetch_next_request():
+        while handled_requests < MAX_REQUESTS_PER_CRAWL and (request := await request_queue.fetch_next_request()):
             url = request.url
 
             if not isinstance(request.user_data['depth'], (str, int)):
@@ -113,5 +118,6 @@ async def main() -> None:
             finally:
                 # Mark the request as handled to ensure it is not processed again.
                 await request_queue.mark_request_as_handled(request)
+                handled_requests += 1
 
         driver.quit()

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -67,13 +67,18 @@ const APIFY_SDK_PYTHON_LATEST_VERSION = spawnSync(PYTHON_COMMAND, ['-m', 'pip', 
     .stdout.toString()
     .match(/\((.*)\)/)[1];
 
-const checkSpawnResult = ({ status, stdout, stderr }) => {
+const checkSpawnResult = ({ status, stdout, stderr, error }) => {
     if (stdout?.toString()) {
         console.log('stdout', stdout.toString());
     }
 
     if (stderr?.toString()) {
         console.log('stderr', stderr?.toString());
+    }
+
+    // A timeout kill leaves status null and sets error — rethrow so the failure names the cause.
+    if (error) {
+        throw error;
     }
 
     expect(status).toBe(0);
@@ -229,10 +234,15 @@ const checkPythonTemplate = () => {
     expect(installedApifySdkVersion).toEqual(APIFY_SDK_PYTHON_LATEST_VERSION);
 };
 
+// Jest's `testTimeout` can't interrupt these synchronous bodies — bound the run here instead.
+const APIFY_RUN_TIMEOUT_MILLIS = 8 * 60 * 1000;
+
 const checkTemplateRun = () => {
     const apifyRunSpawnResult = spawnSync(APIFY_COMMAND, ['run', '--allow-missing-secrets'], {
         env: { ...process.env, APIFY_HEADLESS: '1' },
         stdio: ['pipe', 'inherit', 'inherit'],
+        timeout: APIFY_RUN_TIMEOUT_MILLIS,
+        killSignal: 'SIGKILL',
     });
     checkSpawnResult(apifyRunSpawnResult);
 };

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -67,18 +67,13 @@ const APIFY_SDK_PYTHON_LATEST_VERSION = spawnSync(PYTHON_COMMAND, ['-m', 'pip', 
     .stdout.toString()
     .match(/\((.*)\)/)[1];
 
-const checkSpawnResult = ({ status, stdout, stderr, error }) => {
+const checkSpawnResult = ({ status, stdout, stderr }) => {
     if (stdout?.toString()) {
         console.log('stdout', stdout.toString());
     }
 
     if (stderr?.toString()) {
         console.log('stderr', stderr?.toString());
-    }
-
-    // A timeout kill leaves status null and sets error — rethrow so the failure names the cause.
-    if (error) {
-        throw error;
     }
 
     expect(status).toBe(0);
@@ -234,15 +229,10 @@ const checkPythonTemplate = () => {
     expect(installedApifySdkVersion).toEqual(APIFY_SDK_PYTHON_LATEST_VERSION);
 };
 
-// Jest's `testTimeout` can't interrupt these synchronous bodies — bound the run here instead.
-const APIFY_RUN_TIMEOUT_MILLIS = 8 * 60 * 1000;
-
 const checkTemplateRun = () => {
     const apifyRunSpawnResult = spawnSync(APIFY_COMMAND, ['run', '--allow-missing-secrets'], {
         env: { ...process.env, APIFY_HEADLESS: '1' },
         stdio: ['pipe', 'inherit', 'inherit'],
-        timeout: APIFY_RUN_TIMEOUT_MILLIS,
-        killSignal: 'SIGKILL',
     });
     checkSpawnResult(apifyRunSpawnResult);
 };


### PR DESCRIPTION
> [!NOTE] 
> **TL;DR**
> `python-playwright`, `python-selenium` and `python-beautifulsoup` crawl every link on the live apify.com homepage — 90+ pages — with no request cap, so a slow CI runner blows the 30-minute job budget. Cap them at 10 requests, the way the four Python Crawlee templates already do, and give selenium the per-page timeout the other two get for free. Also fixes a request-queue bug found while reviewing the change.

---

## The flake

[Run 34371908072](https://github.com/apify/actor-templates/actions/runs/34371908072) lost two Windows legs to the 30-minute job timeout. The re-run of the same commit was green in 11 minutes — same code, different outcome, so a flake rather than a regression.

These three templates drive a hand-rolled request-queue loop. The smoke run enqueues every `http(s)` link found on `https://apify.com` — 90-92 pages, about a third of them off-site. Run time is therefore:

```
(number of pages) × (seconds per page)
```

Neither factor was bounded. In the failing leg, 30 of python-playwright's 92 pages hit a 30 s navigation timeout — 15 minutes of dead wait — and the job died with python-selenium still mid-crawl. No test result was reported, and the shard's other three templates never ran.

Across 13 recent runs, 5 of 104 shard-1 Python legs blew up (31m, 31m, 30m, 30m, 26m) against a 6-8 minute median, with a long tail at 20m/18m/14m. Ubuntu was hit too, so this is not a Windows quirk.

## What changed

**Cap the page count (3 templates).** A `MAX_REQUESTS_PER_CRAWL = 10` constant and a counter in the loop condition. This is the convention the four `python-crawlee-*` templates already carry (`max_requests_per_crawl=10`). These three are the only crawling templates in the repo with **neither** a request cap **nor** a host restriction — the JS/TS browser templates without a cap scope their `enqueueLinks` to `globs: ['https://apify.com/*']` with a terminal handler.

**Bound the cost per page (python-selenium).** Capping the count is only half of it. Playwright defaults to a 30 s navigation timeout and httpx to 5 s, so the other two templates were already covered — selenium set nothing and fell through to the 120 s HTTP timeout between the client and chromedriver. `driver.set_page_load_timeout(30)` brings it in line. A slow page now raises `TimeoutException`, which the loop's existing handler logs before moving on, exactly as Playwright's timeout already does.

**Fix a request-queue bug (python-beautifulsoup).** Found reviewing the first commit. The `finally` block marked `new_request` — the last link enqueued, never fetched — instead of `request`. Crawlee short-circuits on a request that is not in progress, so no request was ever marked handled. A/B on a local run: before, 10 `Marking request ... as handled that is not in progress` warnings and `handled_request_count: 0`; after, no warnings and `handled_request_count: 10`.

## Verification

Local, same machine, all three templates:

| | pages crawled | wall time |
|---|---|---|
| before | 272 | 234.7 s |
| after | 30 (10 each) | 49.3 / 48.7 / 45.4 s |

Three consecutive runs gave an identical page count, so it is deterministic now rather than sampled from apify.com's link graph.

CI on the first push of this branch ([run 34389302327](https://github.com/apify/actor-templates/actions/runs/34389302327)): all 16 Python jobs green, worst leg 12 minutes against a 31-minute cancel before. That run is also what exposed the selenium gap — with the crawl already capped, python-selenium still ranged 30 s to 441 s across the eight shard-1 legs, and two single pages in the slowest leg took 111 s and 120 s. Hence the second commit.

Selenium's page-load timeout was verified against a blackholed address: raises `TimeoutException` at the limit, driver stays usable afterwards. Two local runs of the template: 10 pages, 20.5 s and 20.7 s.

`eslint`, `prettier`, `ruff check`, `ruff format --check`, `ty check`, and the non-template Jest suite (17/17) all pass.

## Reverted along the way

An earlier commit added an 8-minute `spawnSync` ceiling to `checkTemplateRun`, so a hung run could not consume the whole job silently. The number was wrong: `ts-crawlee-playwright-camoufox` legitimately runs up to **10m12s** ([run 34330088221](https://github.com/apify/actor-templates/actions/runs/34330088221)), and the ceiling failed a healthy run on this PR. Reverted in 53e19fd0; the harness is unchanged from master.

The idea still has merit — today a hung run kills the job with no test result at all, which is why the original failure took so long to diagnose. It needs a ceiling derived from a sweep of every template's run duration, so it belongs in its own PR.

## For the reviewer

- **Behavior change for users.** Anyone copying these three templates now gets a 10-page demo, and selenium gives up on a page after 30 s. Both match what the rest of the catalog already does.
- **I could not reproduce the original CI failure locally** — my network hit zero page timeouts, so the 30 s multiplier never fired. What is verified locally is the multiplicand: the page count. CI covers the rest.
- **Known remaining soft spot, not addressed here:** the camoufox templates. The Node job in the run above logged `Memory is critically overloaded. Using 3820 MB of 3997 MB (96%)` with 26 navigation timeouts, and `ts-crawlee-playwright-camoufox`'s whole test ranges 81 s to 663 s. Different templates, different cause.
- **One low-severity finding left unfixed**, outside this diff: `page` can be unbound in python-playwright's `finally` if `context.new_page()` raises.
- **`dist/` archives are untouched** — `build_archives.yaml` regenerates them on merge to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)