### PR TITLE
chore: Update templates for base image: apify/actor-node-playwright, apify/actor-node-playwright-chrome, apify/actor-node-playwright-firefox, apify/actor-node-playwright-webkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "jest": "^30.0.0",
         "json5": "^2.2.3",
         "mustache": "^4.2.0",
-        "playwright": "1.61.1",
+        "playwright": "1.63.0",
         "prettier": "^3.9.1",
         "puppeteer": "25.10.0",
         "semver": "^7.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,7 +227,7 @@ importers:
         version: 1.10.0(@types/node@25.9.1)
       crawlee:
         specifier: ^3.15.3
-        version: 3.17.0(@types/node@25.9.1)(playwright@1.61.1)(puppeteer@25.10.0)
+        version: 3.17.0(@types/node@25.9.1)(playwright@1.63.0)(puppeteer@25.10.0)
       eslint:
         specifier: ^9.29.0
         version: 9.39.4
@@ -253,8 +253,8 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0
       playwright:
-        specifier: 1.61.1
-        version: 1.61.1
+        specifier: 1.63.0
+        version: 1.63.0
       prettier:
         specifier: ^3.9.1
         version: 3.9.1
@@ -2315,11 +2315,6 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
-  fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3372,14 +3367,14 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
-  playwright-core@1.61.1:
-    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
-    engines: {node: '>=18'}
+  playwright-core@1.63.0:
+    resolution: {integrity: sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==}
+    engines: {node: '>=20'}
     hasBin: true
 
-  playwright@1.61.1:
-    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
-    engines: {node: '>=18'}
+  playwright@1.63.0:
+    resolution: {integrity: sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==}
+    engines: {node: '>=20'}
     hasBin: true
 
   possible-typed-array-names@1.1.0:
@@ -4466,14 +4461,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@crawlee/browser-pool@3.17.0(playwright@1.61.1)(puppeteer@25.10.0)':
+  '@crawlee/browser-pool@3.17.0(playwright@1.63.0)(puppeteer@25.10.0)':
     dependencies:
       '@apify/log': 2.5.41
       '@apify/timeout': 0.3.5
       '@crawlee/core': 3.17.0
       '@crawlee/types': 3.17.0
       fingerprint-generator: 2.1.82
-      fingerprint-injector: 2.1.82(playwright@1.61.1)(puppeteer@25.10.0)
+      fingerprint-injector: 2.1.82(playwright@1.63.0)(puppeteer@25.10.0)
       lodash.merge: 4.6.2
       nanoid: 3.3.12
       ow: 0.28.2
@@ -4483,23 +4478,23 @@ snapshots:
       tiny-typed-emitter: 2.1.0
       tslib: 2.8.1
     optionalDependencies:
-      playwright: 1.61.1
+      playwright: 1.63.0
       puppeteer: 25.10.0
     transitivePeerDependencies:
       - supports-color
 
-  '@crawlee/browser@3.17.0(playwright@1.61.1)(puppeteer@25.10.0)':
+  '@crawlee/browser@3.17.0(playwright@1.63.0)(puppeteer@25.10.0)':
     dependencies:
       '@apify/timeout': 0.3.5
       '@crawlee/basic': 3.17.0
-      '@crawlee/browser-pool': 3.17.0(playwright@1.61.1)(puppeteer@25.10.0)
+      '@crawlee/browser-pool': 3.17.0(playwright@1.63.0)(puppeteer@25.10.0)
       '@crawlee/types': 3.17.0
       '@crawlee/utils': 3.17.0
       ow: 0.28.2
       tslib: 2.8.1
       type-fest: 4.41.0
     optionalDependencies:
-      playwright: 1.61.1
+      playwright: 1.63.0
       puppeteer: 25.10.0
     transitivePeerDependencies:
       - supports-color
@@ -4618,13 +4613,13 @@ snapshots:
       proper-lockfile: 4.1.2
       tslib: 2.8.1
 
-  '@crawlee/playwright@3.17.0(playwright@1.61.1)(puppeteer@25.10.0)':
+  '@crawlee/playwright@3.17.0(playwright@1.63.0)(puppeteer@25.10.0)':
     dependencies:
       '@apify/datastructures': 2.0.6
       '@apify/log': 2.5.41
       '@apify/timeout': 0.3.5
-      '@crawlee/browser': 3.17.0(playwright@1.61.1)(puppeteer@25.10.0)
-      '@crawlee/browser-pool': 3.17.0(playwright@1.61.1)(puppeteer@25.10.0)
+      '@crawlee/browser': 3.17.0(playwright@1.63.0)(puppeteer@25.10.0)
+      '@crawlee/browser-pool': 3.17.0(playwright@1.63.0)(puppeteer@25.10.0)
       '@crawlee/core': 3.17.0
       '@crawlee/types': 3.17.0
       '@crawlee/utils': 3.17.0
@@ -4637,17 +4632,17 @@ snapshots:
       string-comparison: 1.3.0
       tslib: 2.8.1
     optionalDependencies:
-      playwright: 1.61.1
+      playwright: 1.63.0
     transitivePeerDependencies:
       - puppeteer
       - supports-color
 
-  '@crawlee/puppeteer@3.17.0(playwright@1.61.1)(puppeteer@25.10.0)':
+  '@crawlee/puppeteer@3.17.0(playwright@1.63.0)(puppeteer@25.10.0)':
     dependencies:
       '@apify/datastructures': 2.0.6
       '@apify/log': 2.5.41
-      '@crawlee/browser': 3.17.0(playwright@1.61.1)(puppeteer@25.10.0)
-      '@crawlee/browser-pool': 3.17.0(playwright@1.61.1)(puppeteer@25.10.0)
+      '@crawlee/browser': 3.17.0(playwright@1.63.0)(puppeteer@25.10.0)
+      '@crawlee/browser-pool': 3.17.0(playwright@1.63.0)(puppeteer@25.10.0)
       '@crawlee/types': 3.17.0
       '@crawlee/utils': 3.17.0
       cheerio: 1.0.0-rc.12
@@ -5996,24 +5991,24 @@ snapshots:
 
   countries-list@3.4.0: {}
 
-  crawlee@3.17.0(@types/node@25.9.1)(playwright@1.61.1)(puppeteer@25.10.0):
+  crawlee@3.17.0(@types/node@25.9.1)(playwright@1.63.0)(puppeteer@25.10.0):
     dependencies:
       '@crawlee/basic': 3.17.0
-      '@crawlee/browser': 3.17.0(playwright@1.61.1)(puppeteer@25.10.0)
-      '@crawlee/browser-pool': 3.17.0(playwright@1.61.1)(puppeteer@25.10.0)
+      '@crawlee/browser': 3.17.0(playwright@1.63.0)(puppeteer@25.10.0)
+      '@crawlee/browser-pool': 3.17.0(playwright@1.63.0)(puppeteer@25.10.0)
       '@crawlee/cheerio': 3.17.0
       '@crawlee/cli': 3.17.0(@types/node@25.9.1)
       '@crawlee/core': 3.17.0
       '@crawlee/http': 3.17.0
       '@crawlee/jsdom': 3.17.0
       '@crawlee/linkedom': 3.17.0
-      '@crawlee/playwright': 3.17.0(playwright@1.61.1)(puppeteer@25.10.0)
-      '@crawlee/puppeteer': 3.17.0(playwright@1.61.1)(puppeteer@25.10.0)
+      '@crawlee/playwright': 3.17.0(playwright@1.63.0)(puppeteer@25.10.0)
+      '@crawlee/puppeteer': 3.17.0(playwright@1.63.0)(puppeteer@25.10.0)
       '@crawlee/utils': 3.17.0
       import-local: 3.2.0
       tslib: 2.8.1
     optionalDependencies:
-      playwright: 1.61.1
+      playwright: 1.63.0
       puppeteer: 25.10.0
     transitivePeerDependencies:
       - '@types/node'
@@ -6566,12 +6561,12 @@ snapshots:
       header-generator: 2.1.82
       tslib: 2.8.1
 
-  fingerprint-injector@2.1.82(playwright@1.61.1)(puppeteer@25.10.0):
+  fingerprint-injector@2.1.82(playwright@1.63.0)(puppeteer@25.10.0):
     dependencies:
       fingerprint-generator: 2.1.82
       tslib: 2.8.1
     optionalDependencies:
-      playwright: 1.61.1
+      playwright: 1.63.0
       puppeteer: 25.10.0
 
   flat-cache@4.0.1:
@@ -6613,9 +6608,6 @@ snapshots:
       universalify: 2.0.1
 
   fs.realpath@1.0.0: {}
-
-  fsevents@2.3.2:
-    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -7914,13 +7906,11 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  playwright-core@1.61.1: {}
+  playwright-core@1.63.0: {}
 
-  playwright@1.61.1:
+  playwright@1.63.0:
     dependencies:
-      playwright-core: 1.61.1
-    optionalDependencies:
-      fsevents: 2.3.2
+      playwright-core: 1.63.0
 
   possible-typed-array-names@1.1.0: {}
 

--- a/templates/js-crawlee-playwright-camoufox/package.json
+++ b/templates/js-crawlee-playwright-camoufox/package.json
@@ -10,7 +10,7 @@
         "apify": "^3.7.0",
         "camoufox-js": "^0.12.0",
         "@crawlee/playwright": "^3.15.3",
-        "playwright": "1.59.1"
+        "playwright": "1.63.0"
     },
     "devDependencies": {
         "@apify/eslint-config": "^2.0.0",

--- a/templates/js-crawlee-playwright-chrome/Dockerfile
+++ b/templates/js-crawlee-playwright-chrome/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-playwright-chrome:24-1.61.1
+FROM apify/actor-node-playwright-chrome:24-1.63.0
 
 # Check preinstalled packages
 RUN npm ls @crawlee/core apify puppeteer playwright

--- a/templates/js-crawlee-playwright-chrome/package.json
+++ b/templates/js-crawlee-playwright-chrome/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "apify": "^3.7.0",
         "@crawlee/playwright": "^3.15.3",
-        "playwright": "1.61.1"
+        "playwright": "1.63.0"
     },
     "devDependencies": {
         "@apify/eslint-config": "^2.0.0",

--- a/templates/ts-crawlee-playwright-camoufox/package.json
+++ b/templates/ts-crawlee-playwright-camoufox/package.json
@@ -10,7 +10,7 @@
         "apify": "^3.7.0",
         "camoufox-js": "^0.12.0",
         "@crawlee/playwright": "^3.15.3",
-        "playwright": "1.59.1"
+        "playwright": "1.63.0"
     },
     "devDependencies": {
         "@apify/eslint-config": "^2.0.0",

--- a/templates/ts-crawlee-playwright-chrome/Dockerfile
+++ b/templates/ts-crawlee-playwright-chrome/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-playwright-chrome:24-1.61.1 AS builder
+FROM apify/actor-node-playwright-chrome:24-1.63.0 AS builder
 
 # Check preinstalled packages
 RUN npm ls @crawlee/core apify puppeteer playwright
@@ -25,7 +25,7 @@ COPY --chown=myuser:myuser . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node-playwright-chrome:24-1.61.1
+FROM apify/actor-node-playwright-chrome:24-1.63.0
 
 # Check preinstalled packages
 RUN npm ls @crawlee/core apify puppeteer playwright

--- a/templates/ts-crawlee-playwright-chrome/package.json
+++ b/templates/ts-crawlee-playwright-chrome/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "apify": "^3.7.0",
         "@crawlee/playwright": "^3.15.3",
-        "playwright": "1.61.1"
+        "playwright": "1.63.0"
     },
     "devDependencies": {
         "@apify/eslint-config": "^2.0.0",

--- a/templates/ts-playwright-test-runner/Dockerfile
+++ b/templates/ts-playwright-test-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node-playwright:24-1.61.1
+FROM apify/actor-node-playwright:24-1.63.0
 
 COPY --chown=myuser:myuser package*.json Dockerfile ./
 

--- a/templates/ts-playwright-test-runner/package.json
+++ b/templates/ts-playwright-test-runner/package.json
@@ -23,7 +23,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@playwright/test": "1.61.1",
+        "@playwright/test": "1.63.0",
         "@types/uuid": "^11.0.0",
         "apify": "^3.7.0",
         "uuid": "^14.0.0",


### PR DESCRIPTION
Automated update of templates for base image `apify/actor-node-playwright, apify/actor-node-playwright-chrome, apify/actor-node-playwright-firefox, apify/actor-node-playwright-webkit`

**Parameters:**
- Base Image: `apify/actor-node-playwright, apify/actor-node-playwright-chrome, apify/actor-node-playwright-firefox, apify/actor-node-playwright-webkit`
- Runtime Version: `24`
- Module Version: `1.63.0`

> Generated by [Update Templates](https://github.com/apify/actor-templates/actions/workflows/update-templates.yml) workflow.